### PR TITLE
weightDescriptors supported and IO/initializer distinction made clear

### DIFF
--- a/onnx_xla/backend.h
+++ b/onnx_xla/backend.h
@@ -57,14 +57,14 @@ namespace onnx_xla {
   class XlaExecutor final  {
   public:
     //Used to pass IO metadata and locations to the engine
-    void initIO(uint32_t inputsCount, const onnxTensorDescriptor* inputDescriptors,
+    onnxStatus initIO(uint32_t inputsCount, const onnxTensorDescriptor* inputDescriptors,
                 uint32_t  outputsCount, const onnxTensorDescriptor* outputDescriptors);
 
     //Sends input tensor values to the server
-    void sendInputs();
+    onnxStatus sendInputs();
 
     //Runs the computation on the server using passed input 
-    void executeComputation();
+    onnxStatus executeComputation();
 
   private:
     //computation to be run
@@ -122,7 +122,8 @@ namespace onnx_xla {
     //    TODO: Fix kUndefinded translation, which is present for relu test
     //    TODO: Make function registry
     //  Fills up exector_'s output names
-    void translateGraph();
+    //  Returns status
+    onnxStatus translateGraph();
 
     //Used to get handle to XlaExecutor
     //NOTE: Can only be called on once as it releases the unique pointer. Freeing
@@ -163,24 +164,26 @@ namespace onnx_xla {
     //Create ConstantLiteral XlaOps for initializers/weights, verifying weight descriptors;
     //Creates params for other runtime inputs
     //Fill executor_'s input metadata (type, shape) to be verified later
-    void handleInputs();
+    onnxStatus handleInputs();
 
     //Fill output_names_
     //Create output XlaOp
     //Fill executor_'s output metadata (type, shape) to be verified later
-    void handleOutputs();
+    onnxStatus handleOutputs();
   };
 
   //Engine to build up an IR graph from proto bytes format. Model validation and 
   //shape inference for entire graph is conducted here.
   class OnnxParser {
   public:
-    //Constructs ModelProto from byte form
+    //Initializes parser
     OnnxParser(const void* serializedModel, size_t serializedModelSize);
 
-    //Shape inference and model validation, followed by conversion to IR
-    std::unique_ptr<Graph> parse();
+    //Deserialize to modelProto, shape inference, and conversion to IR 
+    //(model validation) stored in ir
+    onnxStatus parse(std::unique_ptr<Graph>& ir);
   private:
-    ModelProto model_;
+    const void* serialized_model_;
+    size_t serialized_model_size_;
   };
 }

--- a/onnx_xla/backend.h
+++ b/onnx_xla/backend.h
@@ -50,30 +50,29 @@ namespace onnx_xla {
   class OnnxParser;
 
   //Engine to execute an XlaComputation constructed by XlaTransform. The computation_
-  //and static_literals_ are filled by the XlaTransform object. To run, call initIO to
-  //verify IO metadata and to send IO locations. Once IO data is present, execute sendLiterals
+  //is filled by the XlaTransform object. To run, call initIO to verify IO
+  //metadata and to declare IO locations. Once IO data is present, execute sendInputs
   //and executeComputation to run. If successful, output tensors will be present at the 
   //output_buffers_ pointers.
   class XlaExecutor final  {
   public:
-    //initIO: used to pass I/O tensor values and metadata to the engine
+    //Used to pass IO metadata and locations to the engine
     void initIO(uint32_t inputsCount, const onnxTensorDescriptor* inputDescriptors,
                 uint32_t  outputsCount, const onnxTensorDescriptor* outputDescriptors);
 
-    //sendLiterals: sends constants and input tensors to the server
-    void sendLiterals();
+    //Sends input tensor values to the server
+    void sendInputs();
 
-    //executeComputation: runs the computation on the server using passed data 
+    //Runs the computation on the server using passed input 
     void executeComputation();
 
   private:
-    //computation_: computation to be run
+    //computation to be run
     XlaComputation computation_;
 
-    //static_literals_: weights passed from initializers
-    std::vector<std::unique_ptr<Literal>> static_literals_;
-
-    //arguments_: weight and IO data to be passed to the server
+    //Input data to be passed to the server
+      //Filled in by sendInputs
+      //Used by executeComputation
     std::vector<GlobalData*> arguments_;
 
     //Store IO metadata to 
@@ -86,12 +85,16 @@ namespace onnx_xla {
     std::unordered_map<std::string, onnxPointer> input_buffers_;
     std::unordered_map<std::string, onnxPointer> output_buffers_;
 
-    //output_names_: order of this vector corresponds to order of returned literals
+    //Mapping of parameter number to input name; use to fill arguments_ in the correct order
+    std::vector<std::string> param_input_name_;
+
+    //Used to copy output returned from XLA to output buffers 
     std::vector<std::string> output_names_;
 
-    //Helper functions to translate weights and inputs to literals
+    //Helper functions to translate tensors, inputs, and weights to literals
     std::unique_ptr<Literal> tensorToLiteral(const Tensor& t);
-    std::unique_ptr<Literal> inputToLiteral(const std::string& name);
+    std::unique_ptr<Literal> inputNameToLiteral(const std::string& name);
+    std::unique_ptr<Literal> descriptorToLiteral(const onnxTensorDescriptor& t);
     
     friend class XlaTransform;
   };
@@ -99,22 +102,25 @@ namespace onnx_xla {
 
   //Engine to transform an IR graph to a form that can be executed by the XLA server.
   //When the object is constructed, ownership of the IR graph is passed to it. Then,
-  //execute translateGraph to build up the XlaExecutor object (and thus the XlaComputation.
+  //execute translateGraph to build up the XlaExecutor object (and thus the XlaComputation).
   //To get the handle on the XlaExecutor that is constructed, call executor() (can only be
   //done once).
   class XlaTransform final  {
   public:
-    //Passes IR graph to be transformed and name of builder
+    //Passes IR graph to be transformed, name of builder, and weightDescriptor info
     //TODO: Remove build_name? or keep for debugging purposes?
     XlaTransform(std::unique_ptr<Graph> ir,
-                 const std::string& build_name);
+                 const std::string& build_name,
+                 uint32_t weightsCount, 
+                 const onnxTensorDescriptor *weightDescriptors);
     ~XlaTransform();
 
-    //Fills up XlaExecutor based on the IR graph given
-    //  Fills up executor_->static_literals_ from initializers
+    //Fills up XlaExecutor based on the IR graph. Function accomplishes:
+    //  Initializer/weight values added as constants to the graph 
     //  Fills up executor_'s expected IO metadata, which can be verified in initIO
     //  Translates IR graph node by node 
     //    TODO: Fix kUndefinded translation, which is present for relu test
+    //    TODO: Make function registry
     //  Fills up exector_'s output names
     void translateGraph();
 
@@ -126,6 +132,10 @@ namespace onnx_xla {
   private:
     //IR graph to be translated
     std::unique_ptr<Graph> ir_;
+
+    //Weight Descriptor information
+    uint32_t weights_count_;
+    const onnxTensorDescriptor* weight_descriptors_;
 
     //Builder that builds XlaComputation
     //  TODO: Remove? Currently only used by one function
@@ -139,19 +149,26 @@ namespace onnx_xla {
     std::unordered_map<const Value*, XlaOp> value_to_op_;
 
     //Keeps track of number of parameters in computation
+    //  TODO: Make local? Only used by one function
     int64 global_param_number_;
 
     //Helper to get shape of associated value
-    //TODO: make static
-    Shape shapeOfValue(const Value* v);
+    static inline Shape shapeOfValue(const Value* v);
 
     //Helpers to register value with and operation in value_to_op_
     void registerValueOp(const Value* v, XlaOp& op);
     void registerValueOp(const Value* v, XlaOp& op, int index);
 
-    //Fill executor_'s IO metadata (type, shape) to be verified later by
-    //the executor_
-    void fillIOMetadata();
+
+    //Create ConstantLiteral XlaOps for initializers/weights, verifying weight descriptors;
+    //Creates params for other runtime inputs
+    //Fill executor_'s input metadata (type, shape) to be verified later
+    void handleInputs();
+
+    //Fill output_names_
+    //Create output XlaOp
+    //Fill executor_'s output metadata (type, shape) to be verified later
+    void handleOutputs();
   };
 
   //Engine to build up an IR graph from proto bytes format. Model validation and 

--- a/onnx_xla/backend.h
+++ b/onnx_xla/backend.h
@@ -56,16 +56,23 @@ namespace onnx_xla {
   //output_buffers_ pointers.
   class XlaExecutor final  {
   public:
+    //Constructor initialized with backend handle
+    XlaExecutor(onnxBackend backend);
+
     //Used to pass IO metadata and locations to the engine
     onnxStatus initIO(uint32_t inputsCount, const onnxTensorDescriptor* inputDescriptors,
                 uint32_t  outputsCount, const onnxTensorDescriptor* outputDescriptors);
 
     //Sends input tensor values to the server
-    onnxStatus sendInputs();
+    //Input fence (initialized) signals when inputs are ready
+    onnxStatus sendInputs(const onnxMemoryFence* inputFence);
 
     //Runs the computation on the server using passed input 
-    onnxStatus executeComputation();
+    //outputFence (initialized) is signalled once outputs are ready
+    onnxStatus executeComputation(onnxMemoryFence* outputFence);
 
+    //backend handle
+    const onnxBackend backend_;
   private:
     //computation to be run
     XlaComputation computation_;
@@ -109,7 +116,8 @@ namespace onnx_xla {
   public:
     //Passes IR graph to be transformed, name of builder, and weightDescriptor info
     //TODO: Remove build_name? or keep for debugging purposes?
-    XlaTransform(std::unique_ptr<Graph> ir,
+    XlaTransform(onnxBackend backend,
+                 std::unique_ptr<Graph> ir,
                  const std::string& build_name,
                  uint32_t weightsCount, 
                  const onnxTensorDescriptor *weightDescriptors);

--- a/onnx_xla/backend_test.cc
+++ b/onnx_xla/backend_test.cc
@@ -106,7 +106,7 @@ namespace onnx_xla  {
     input.buffer = (onnxPointer) new float[24];
 
     //Execute using XLA backend
-    XlaTransform runner(std::move(relu_graph), "relu", 0, NULL);
+    XlaTransform runner(std::move(relu_graph), "relu", 0, nullptr);
     runner.translateGraph();
     auto executor = runner.executor();
     executor->initIO(1, &input, 1, &output);

--- a/onnx_xla/backend_test.cc
+++ b/onnx_xla/backend_test.cc
@@ -48,11 +48,11 @@ namespace onnx_xla  {
     output.buffer = (onnxPointer) new float[24];
    
      //Execute using XLA backend
-    XlaTransform runner(std::move(relu_graph), "relu");
+    XlaTransform runner(std::move(relu_graph), "relu", 0, NULL);
     runner.translateGraph();
     auto executor = runner.executor();
     executor->initIO(0, nullptr, 1, &output);
-    executor->sendLiterals();
+    executor->sendInputs();
     executor->executeComputation();
 
     delete executor; 
@@ -106,7 +106,7 @@ namespace onnx_xla  {
     input.buffer = (onnxPointer) new float[24];
 
     //Execute using XLA backend
-    XlaTransform runner(std::move(relu_graph), "relu");
+    XlaTransform runner(std::move(relu_graph), "relu", 0, NULL);
     runner.translateGraph();
     auto executor = runner.executor();
     executor->initIO(1, &input, 1, &output);
@@ -117,7 +117,7 @@ namespace onnx_xla  {
       std::mt19937 rand_engine(rand_dev());
       input_ptr[i] = unif(rand_engine);
     }
-    executor->sendLiterals();
+    executor->sendInputs();
     executor->executeComputation();
 
     delete executor;

--- a/onnx_xla/backend_test.cc
+++ b/onnx_xla/backend_test.cc
@@ -36,7 +36,7 @@ namespace onnx_xla  {
     relu_output->setSizes(sizes);
     relu_output->setUniqueName("relu_output");
     relu_graph->return_node()->addInput(relu_output);
-    
+
     //Set up IO information
     uint64_t shape[3] = {2, 3, 4};
     onnxTensorDescriptor output;
@@ -46,19 +46,19 @@ namespace onnx_xla  {
     output.dimensions = 3;
     output.shape = shape;
     output.buffer = (onnxPointer) new float[24];
- 
+
     //Setup events
     //Hacky event usage to make it work (cannot use onnxifi with backend)
     onnxMemoryFence inputFence;
     inputFence.type = ONNXIFI_SYNCHRONIZATION_EVENT;
     auto inputEvent = new EventControl();
     inputEvent->signalled_ = true;
-    *inputFence.event = reinterpret_cast<onnxEvent*>(&inputEvent);
+    inputFence.event = reinterpret_cast<onnxEvent*>(&inputEvent);
     onnxMemoryFence outputFence;
     outputFence.type = ONNXIFI_SYNCHRONIZATION_EVENT;
     auto outputEvent = new EventControl();
     outputEvent->signalled_ = false;
-    *outputFence.event = reinterpret_cast<onnxEvent*>(&outputEvent);
+    outputFence.event = reinterpret_cast<onnxEvent*>(&outputEvent);
  
     //Execute using XLA backend
     XlaTransform runner(NULL, std::move(relu_graph), "relu", 0, nullptr);
@@ -129,12 +129,12 @@ namespace onnx_xla  {
     inputFence.type = ONNXIFI_SYNCHRONIZATION_EVENT;
     auto inputEvent = new EventControl();
     inputEvent->signalled_ = true;
-    *inputFence.event = reinterpret_cast<onnxEvent*>(&inputEvent);
+    inputFence.event = reinterpret_cast<onnxEvent*>(&inputEvent);
     onnxMemoryFence outputFence;
     outputFence.type = ONNXIFI_SYNCHRONIZATION_EVENT;
     auto outputEvent = new EventControl();
     outputEvent->signalled_ = false;
-    *outputFence.event = reinterpret_cast<onnxEvent*>(&outputEvent);
+    outputFence.event = reinterpret_cast<onnxEvent*>(&outputEvent);
 
     //Execute using XLA backend
     XlaTransform runner(NULL, std::move(relu_graph), "relu", 0, nullptr);

--- a/onnx_xla/onnx_xla_interface.cc
+++ b/onnx_xla/onnx_xla_interface.cc
@@ -228,6 +228,7 @@ ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI ONNXIFI_SYMBOL_NAME(
                    const onnxTensorDescriptor *weightDescriptors,
                    onnxGraph *graph) {
   onnxifiTryCatch([&] {
+    *graph = NULL;
     if (!backend) {
       return ONNXIFI_STATUS_INVALID_BACKEND;
     }

--- a/onnx_xla/onnx_xla_interface.cc
+++ b/onnx_xla/onnx_xla_interface.cc
@@ -13,7 +13,7 @@ onnxStatus onnxifiTryCatch(std::function<onnxStatus()> tryBlock)  {
     return tryBlock();          
   }
   catch (const std::bad_alloc& e) {                                            
-    std::cout << "Allocation failed: " << e.what() << std::endl;               
+    std::cerr << "Allocation failed: " << e.what() << std::endl;               
     return ONNXIFI_STATUS_NO_SYSTEM_MEMORY;                                    
   }                                                                            
   catch (const std::exception &e) {                                            

--- a/onnx_xla/onnxifi_helper.cc
+++ b/onnx_xla/onnxifi_helper.cc
@@ -1,0 +1,28 @@
+#include "onnxifi_helper.h"
+
+EventControl::EventControl() : signalled_(false) {}
+
+BackendControl::BackendControl(OnnxXlaBackendID* id) : backendID(id) {}
+
+onnxStatus BackendControl::build(const void* serializedModel, size_t serializedModelSize,
+                                 uint32_t weightsCount, const onnxTensorDescriptor *weightDescriptors, 
+                                 onnxGraph* graph) {
+
+  onnx_xla::OnnxParser parser(serializedModel, serializedModelSize);
+  std::unique_ptr<ONNX_NAMESPACE::Graph> ir(nullptr);
+  auto parseStatus = parser.parse(ir);
+  if (parseStatus != ONNXIFI_STATUS_SUCCESS)  {
+    return parseStatus;
+  }
+  std::string build_name = ir->name();
+  onnx_xla::XlaTransform runner(reinterpret_cast<onnxBackend>(this),
+                                std::move(ir), build_name,
+                                weightsCount, weightDescriptors);
+  auto translateStatus = runner.translateGraph();
+  if (translateStatus != ONNXIFI_STATUS_SUCCESS)  {
+    return translateStatus;
+  }
+
+  *graph = reinterpret_cast<onnxGraph>(runner.executor());
+  return ONNXIFI_STATUS_SUCCESS;
+}

--- a/onnx_xla/onnxifi_helper.h
+++ b/onnx_xla/onnxifi_helper.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "backend.h"
+
+
+//TODO: More formal representation of backendID - CPU, GPU, TPU?
+struct OnnxXlaBackendID {
+  int device_id{0};
+};
+
+struct EventControl {
+  EventControl();
+  volatile bool signalled_;
+  std::mutex mutex_;
+  std::condition_variable condvar_;
+};
+
+
+//Backend engine
+//  backendID will eventually determine translation detail
+struct BackendControl {
+public:
+  BackendControl(OnnxXlaBackendID* id);
+
+  //use OnnxParser and XlaTransform to fill *graph
+  onnxStatus build(const void* serializedModel, size_t serializedModelSize, uint32_t weightsCount,
+                   const onnxTensorDescriptor *weightDescriptors, onnxGraph* graph);
+
+private:
+  OnnxXlaBackendID* backendID;
+};
+
+

--- a/onnx_xla/types.cc
+++ b/onnx_xla/types.cc
@@ -49,38 +49,4 @@ namespace onnx_xla  {
       }
     }
   }
-
-  ONNX_NAMESPACE::TensorProto_DataType onnxifiToOnnx(const onnxEnum& data_type)  {
-    switch(data_type)  {
-      case ONNXIFI_DATATYPE_FLOAT16:  {
-        return ONNX_NAMESPACE::TensorProto_DataType_FLOAT16;
-      }
-      case ONNXIFI_DATATYPE_FLOAT32:  {
-        return ONNX_NAMESPACE::TensorProto_DataType_FLOAT;
-      }
-      case ONNXIFI_DATATYPE_INT8:  {
-        return ONNX_NAMESPACE::TensorProto_DataType_INT8;      
-      }
-      case ONNXIFI_DATATYPE_INT16:  {
-        return ONNX_NAMESPACE::TensorProto_DataType_INT16;
-      }
-      case ONNXIFI_DATATYPE_INT32:  {
-        return ONNX_NAMESPACE::TensorProto_DataType_INT32;      
-      }
-      case ONNXIFI_DATATYPE_UINT8:  {
-        return ONNX_NAMESPACE::TensorProto_DataType_UINT8;
-      }
-      case ONNXIFI_DATATYPE_UINT16:  {
-        return ONNX_NAMESPACE::TensorProto_DataType_UINT16;    
-      }
-      case ONNXIFI_DATATYPE_UINT32:  {
-        return ONNX_NAMESPACE::TensorProto_DataType_UINT32;     
-      }
-      default:  {
-        throw("Not supported");
-      }
-
-    }
-  }
-
 }

--- a/onnx_xla/types.h
+++ b/onnx_xla/types.h
@@ -31,9 +31,6 @@ namespace onnx_xla  {
 
    using ::Eigen::half;
 
-   //Helper functions to translate between types
-   //TODO: Remove onnxifiToOnnx as apparently the two have the same values
+   //Helper functions to translate between ONNX and XLA types
    xla::PrimitiveType onnxToPrimitive(const ONNX_NAMESPACE::TensorProto_DataType& data_type);
-   ONNX_NAMESPACE::TensorProto_DataType onnxifiToOnnx(const onnxEnum& data_type);
-   
 }


### PR DESCRIPTION
Support for weight descriptors added.
Removed bug that relied on the order of inputs to execute the computation.
Distinction between parameters and constants on the XLA side (before initializers were incorrectly made parameters).
Should now be able to run graph with different inputs.