### PR TITLE
fused executeComputation and sendInputs; added run test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ else()
   target_include_directories(python_onnxifi PRIVATE ${PROJECT_SOURCE_DIR}/third_party/pybind11/include)
 endif()
 
-target_link_libraries(python_onnxifi PRIVATE onnx_xla)
+target_link_libraries(python_onnxifi PRIVATE -Wl,--whole-archive onnx_xla -Wl,--no-whole-archive)
 
 # binaries
 file(GLOB_RECURSE binaries

--- a/onnx_xla/backend.cc
+++ b/onnx_xla/backend.cc
@@ -1,345 +1,354 @@
 #include "onnx_xla/backend.h"
 
 namespace onnx_xla {
-  XlaExecutor::XlaExecutor(onnxBackend backend) : backend_(backend) {}
+XlaExecutor::XlaExecutor(onnxBackend backend) : backend_(backend) {}
 
-  #define SWITCH(data_type)                                                    \
-    switch(data_type) {                                                        \
-      case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:  {                      \
-        OPERATION(float, float, floats)                                        \
-      }                 						       \
-      case ONNX_NAMESPACE::TensorProto_DataType_COMPLEX64: {		       \
-        OPERATION(complex64, complex64, floats)    			       \
-      } 								       \
-      case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16:  {		       \
-        OPERATION(int32_t, half, int32s)				       \
-      } 								       \
-      case ONNX_NAMESPACE::TensorProto_DataType_BOOL:  {		       \
-        OPERATION(int32_t, bool, int32s)				       \
-      } 								       \
-      case ONNX_NAMESPACE::TensorProto_DataType_INT8:  {		       \
-        OPERATION(int32_t, int8, int32s)				       \
-      } 								       \
-      case ONNX_NAMESPACE::TensorProto_DataType_INT16:  {		       \
-        OPERATION(int32_t, int16, int32s)				       \
-      } 								       \
-      case ONNX_NAMESPACE::TensorProto_DataType_INT32:  {		       \
-        OPERATION(int32_t, int32, int32s)				       \
-      }         							       \
-      case ONNX_NAMESPACE::TensorProto_DataType_UINT8:  {		       \
-        OPERATION(int32_t, uint8, int32s)				       \
-      } 								       \
-      case ONNX_NAMESPACE::TensorProto_DataType_UINT16:  {		       \
-        OPERATION(int32_t, uint16, int32s)			               \
-      }          							       \
-      case ONNX_NAMESPACE::TensorProto_DataType_INT64:  {		       \
-        OPERATION(int64_t, int64, int64s)				       \
-      } 								       \
-      case ONNX_NAMESPACE::TensorProto_DataType_UINT32:  {		       \
-        OPERATION(uint64_t, uint32, uint64s)				       \
-      } 								       \
-      case ONNX_NAMESPACE::TensorProto_DataType_UINT64:  {		       \
-        OPERATION(uint64_t, uint64, uint64s)				       \
-      } 								       \
-      case ONNX_NAMESPACE::TensorProto_DataType_DOUBLE:  {                     \
-        OPERATION(double, double, doubles) 				       \
-      } 								       \
-      case ONNX_NAMESPACE::TensorProto_DataType_COMPLEX128:		       \
-      case ONNX_NAMESPACE::TensorProto_DataType_STRING:			       \
-      case ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED:		       \
-      default:  {							       \
-        throw std::runtime_error("Tensor not of a convertible data type.");    \
-      }  								       \
-    }  									       \
-
-  std::unique_ptr<Literal> XlaExecutor::tensorToLiteral(const Tensor& t) {
-
-    #define OPERATION(type_from, type_to, vec)                                 \
-      type_from* t_data;                                                       \
-      if (t.is_raw_data())  {                                                  \
-        t_data = (type_from*) t.raw().c_str();                                 \
-      } else {                                                                 \
-        t_data = (type_from*) t.vec().data();                                  \
-      }                                                                        \
-      std::vector<int64> sizes;                                                \
-      for (auto n : t.sizes()) {                                               \
-        sizes.push_back(n);                                                    \
-      }                                                                        \
-      auto l = std::unique_ptr<Literal>(new Literal(ShapeUtil::MakeShape(      \
-               NativeToPrimitiveType<type_to>(), sizes)));                     \
-      int64 num_elements = std::accumulate(sizes.begin(),                      \
-                                             sizes.end(),                      \
-			    (int64) 1, std::multiplies<int64>());              \
-      tensorflow::gtl::MutableArraySlice<type_to> l_data = l->data<type_to>(); \
-      for (auto i = 0; i < num_elements; ++i) {                                \
-        l_data[i] = (type_to) t_data[i];                                       \
-      }									       \
-      return l;                                                                \
-    
-    SWITCH(t.elem_type())
-    #undef OPERATION
+#define SWITCH(data_type)                                                 \
+  switch (data_type) {                                                    \
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT: {                    \
+      OPERATION(float, float, floats)                                     \
+    }                                                                     \
+    case ONNX_NAMESPACE::TensorProto_DataType_COMPLEX64: {                \
+      OPERATION(complex64, complex64, floats)                             \
+    }                                                                     \
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16: {                  \
+      OPERATION(int32_t, half, int32s)                                    \
+    }                                                                     \
+    case ONNX_NAMESPACE::TensorProto_DataType_BOOL: {                     \
+      OPERATION(int32_t, bool, int32s)                                    \
+    }                                                                     \
+    case ONNX_NAMESPACE::TensorProto_DataType_INT8: {                     \
+      OPERATION(int32_t, int8, int32s)                                    \
+    }                                                                     \
+    case ONNX_NAMESPACE::TensorProto_DataType_INT16: {                    \
+      OPERATION(int32_t, int16, int32s)                                   \
+    }                                                                     \
+    case ONNX_NAMESPACE::TensorProto_DataType_INT32: {                    \
+      OPERATION(int32_t, int32, int32s)                                   \
+    }                                                                     \
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT8: {                    \
+      OPERATION(int32_t, uint8, int32s)                                   \
+    }                                                                     \
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT16: {                   \
+      OPERATION(int32_t, uint16, int32s)                                  \
+    }                                                                     \
+    case ONNX_NAMESPACE::TensorProto_DataType_INT64: {                    \
+      OPERATION(int64_t, int64, int64s)                                   \
+    }                                                                     \
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT32: {                   \
+      OPERATION(uint64_t, uint32, uint64s)                                \
+    }                                                                     \
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT64: {                   \
+      OPERATION(uint64_t, uint64, uint64s)                                \
+    }                                                                     \
+    case ONNX_NAMESPACE::TensorProto_DataType_DOUBLE: {                   \
+      OPERATION(double, double, doubles)                                  \
+    }                                                                     \
+    case ONNX_NAMESPACE::TensorProto_DataType_COMPLEX128:                 \
+    case ONNX_NAMESPACE::TensorProto_DataType_STRING:                     \
+    case ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED:                  \
+    default: {                                                            \
+      throw std::runtime_error("Tensor not of a convertible data type."); \
+    }                                                                     \
   }
 
-  std::unique_ptr<Literal> XlaExecutor::inputNameToLiteral(const std::string& name) {
-    std::vector<int64> sizes;
-    for (auto i = 0; i < io_shape_[name].size(); ++i) {  
-      sizes.push_back((int64) io_shape_[name][i].dim);    
-    }
-    int64 num_elements = std::accumulate(sizes.begin(), sizes.end(),    
-                                         (int64) 1, std::multiplies<int64>());           
+std::unique_ptr<Literal> XlaExecutor::tensorToLiteral(const Tensor& t) {
+#define OPERATION(type_from, type_to, vec)                                   \
+  type_from* t_data;                                                         \
+  if (t.is_raw_data()) {                                                     \
+    t_data = (type_from*)t.raw().c_str();                                    \
+  } else {                                                                   \
+    t_data = (type_from*)t.vec().data();                                     \
+  }                                                                          \
+  std::vector<int64> sizes;                                                  \
+  for (auto n : t.sizes()) {                                                 \
+    sizes.push_back(n);                                                      \
+  }                                                                          \
+  auto l = std::unique_ptr<Literal>(new Literal(                             \
+      ShapeUtil::MakeShape(NativeToPrimitiveType<type_to>(), sizes)));       \
+  int64 num_elements = std::accumulate(sizes.begin(), sizes.end(), (int64)1, \
+                                       std::multiplies<int64>());            \
+  tensorflow::gtl::MutableArraySlice<type_to> l_data = l->data<type_to>();   \
+  for (auto i = 0; i < num_elements; ++i) {                                  \
+    l_data[i] = (type_to)t_data[i];                                          \
+  }                                                                          \
+  return l;
 
-    #define OPERATION(type_from, type_to, vec)                                 \
-      auto l = std::unique_ptr<Literal>(new Literal(ShapeUtil::MakeShape(      \
-               NativeToPrimitiveType<type_to>(), sizes)));                     \
-      tensorflow::gtl::MutableArraySlice<type_to> l_data = l->data<type_to>(); \
-      ONNX_ASSERT(input_buffers_[name]);                                       \
-      type_from* inputData = (type_from*) input_buffers_[name];                \
-      for (auto i = 0; i < num_elements; ++i) {                                \
-        l_data[i] = (type_to) inputData[i];                                    \
-      }                                                                        \
-      return l;                                                                \
+  SWITCH(t.elem_type())
+#undef OPERATION
+}
 
-    SWITCH(io_data_type_[name])
-    #undef OPERATION
+std::unique_ptr<Literal> XlaExecutor::inputNameToLiteral(
+    const std::string& name) {
+  std::vector<int64> sizes;
+  for (auto i = 0; i < io_shape_[name].size(); ++i) {
+    sizes.push_back((int64)io_shape_[name][i].dim);
+  }
+  int64 num_elements = std::accumulate(sizes.begin(), sizes.end(), (int64)1,
+                                       std::multiplies<int64>());
+
+#define OPERATION(type_from, type_to, vec)                                 \
+  auto l = std::unique_ptr<Literal>(new Literal(                           \
+      ShapeUtil::MakeShape(NativeToPrimitiveType<type_to>(), sizes)));     \
+  tensorflow::gtl::MutableArraySlice<type_to> l_data = l->data<type_to>(); \
+  ONNX_ASSERT(input_buffers_[name]);                                       \
+  type_from* inputData = (type_from*)input_buffers_[name];                 \
+  for (auto i = 0; i < num_elements; ++i) {                                \
+    l_data[i] = (type_to)inputData[i];                                     \
+  }                                                                        \
+  return l;
+
+  SWITCH(io_data_type_[name])
+#undef OPERATION
+}
+
+std::unique_ptr<Literal> XlaExecutor::descriptorToLiteral(
+    const onnxTensorDescriptor& t) {
+  std::vector<int64> sizes(&t.shape[0], &t.shape[t.dimensions]);
+  int64 num_elements = std::accumulate(sizes.begin(), sizes.end(), (int64)1,
+                                       std::multiplies<int64>());
+
+#define OPERATION(type_from, type_to, vec)                                 \
+  auto l = std::unique_ptr<Literal>(new Literal(                           \
+      ShapeUtil::MakeShape(NativeToPrimitiveType<type_to>(), sizes)));     \
+  tensorflow::gtl::MutableArraySlice<type_to> l_data = l->data<type_to>(); \
+  type_from* inputData = (type_from*)t.buffer;                             \
+  for (auto i = 0; i < num_elements; ++i) {                                \
+    l_data[i] = (type_to)inputData[i];                                     \
+  }                                                                        \
+  return l;
+
+  SWITCH(t.dataType)
+#undef OPERATION
+}
+
+onnxStatus XlaExecutor::initIO(uint32_t inputsCount,
+                               const onnxTensorDescriptor* inputDescriptors,
+                               uint32_t outputsCount,
+                               const onnxTensorDescriptor* outputDescriptors) {
+  if (num_inputs_ != inputsCount) {
+    throw std::runtime_error("Did not receive expected number of inputs");
+  }
+  if (num_outputs_ != outputsCount) {
+    throw std::runtime_error("Did not receive expected number of outputs");
   }
 
-  std::unique_ptr<Literal> XlaExecutor::descriptorToLiteral(const onnxTensorDescriptor& t) {
-    std::vector<int64> sizes(&t.shape[0], &t.shape[t.dimensions]);
-    int64 num_elements = std::accumulate(sizes.begin(), sizes.end(),
-                                         (int64) 1, std::multiplies<int64>());
-
-    #define OPERATION(type_from, type_to, vec)                                 \
-      auto l = std::unique_ptr<Literal>(new Literal(ShapeUtil::MakeShape(      \
-               NativeToPrimitiveType<type_to>(), sizes)));                     \
-      tensorflow::gtl::MutableArraySlice<type_to> l_data = l->data<type_to>(); \
-      type_from* inputData = (type_from*) t.buffer;                            \
-      for (auto i = 0; i < num_elements; ++i) {                                \
-        l_data[i] = (type_to) inputData[i];                                    \
-      }                                                                        \
-      return l;                                                                \
-
-    SWITCH(t.dataType)
-    #undef OPERATION
+#define CHECK_TYPE_AND_SHAPE(VAR)                                   \
+  for (auto i = 0; i < num_##VAR##s_; ++i) {                        \
+    const std::string name(VAR##Descriptors[i].name);               \
+    if (io_data_type_.find(name) == io_data_type_.end()) {          \
+      return ONNXIFI_STATUS_INVALID_NAME;                           \
+    }                                                               \
+    VAR##_buffers_[name] = VAR##Descriptors[i].buffer;              \
+    if (VAR##Descriptors[i].dataType != io_data_type_[name]) {      \
+      return ONNXIFI_STATUS_MISMATCHING_DATATYPE;                   \
+    }                                                               \
+    if (VAR##Descriptors[i].dimensions != io_shape_[name].size()) { \
+      return ONNXIFI_STATUS_MISMATCHING_SHAPE;                      \
+    }                                                               \
+    for (auto j = 0; j < io_shape_[name].size(); ++j) {             \
+      if (!io_shape_[name][j].is_int ||                             \
+          io_shape_[name][j].dim != VAR##Descriptors[i].shape[j]) { \
+        return ONNXIFI_STATUS_MISMATCHING_SHAPE;                    \
+      }                                                             \
+    }                                                               \
   }
 
-  onnxStatus XlaExecutor::initIO(uint32_t inputsCount, const onnxTensorDescriptor* inputDescriptors,
-                           uint32_t  outputsCount, const onnxTensorDescriptor* outputDescriptors) {
-    if (num_inputs_ != inputsCount)  {
-      throw std::runtime_error("Did not receive expected number of inputs");
-    }
-    if (num_outputs_ != outputsCount)  {
-      throw std::runtime_error("Did not receive expected number of outputs");
-    }
-    
-    #define CHECK_TYPE_AND_SHAPE(VAR)                                           \
-      for (auto i = 0; i < num_##VAR##s_; ++i)  {                               \
-        const std::string name(VAR##Descriptors[i].name);                       \
-        if (io_data_type_.find(name) == io_data_type_.end())  {                 \
-          return ONNXIFI_STATUS_INVALID_NAME;                                   \
-        }                                                                       \
-        VAR##_buffers_[name] = VAR##Descriptors[i].buffer;                      \
-        if (VAR##Descriptors[i].dataType != io_data_type_[name])  {             \
-          return ONNXIFI_STATUS_MISMATCHING_DATATYPE;                           \
-        } 									\
-        if (VAR##Descriptors[i].dimensions != io_shape_[name].size())  {        \
-          return ONNXIFI_STATUS_MISMATCHING_SHAPE;                              \
-        }									\
-        for (auto j = 0; j < io_shape_[name].size(); ++j)  {                    \
-          if(!io_shape_[name][j].is_int ||                                      \
-             io_shape_[name][j].dim != VAR##Descriptors[i].shape[j])  {         \
-            return ONNXIFI_STATUS_MISMATCHING_SHAPE;                            \
-          }                							\
-        }                                                                       \
-      }                                                                         \
+  CHECK_TYPE_AND_SHAPE(input);
+  CHECK_TYPE_AND_SHAPE(output);
+  return ONNXIFI_STATUS_SUCCESS;
+#undef CHECK_TYPE_AND_SHAPE
+}
 
-    CHECK_TYPE_AND_SHAPE(input);
-    CHECK_TYPE_AND_SHAPE(output);
-    return ONNXIFI_STATUS_SUCCESS;
-    #undef CHECK_TYPE_AND_SHAPE
+onnxStatus XlaExecutor::executeComputation(const onnxMemoryFence* inputFence,
+                                           onnxMemoryFence* outputFence) {
+  std::vector<GlobalData*> arguments;
+  auto waitStatus = onnxWaitEvent(*inputFence->event);
+  if (waitStatus != ONNXIFI_STATUS_SUCCESS) {
+    return waitStatus;
   }
+  for (const std::string& s : param_input_name_) {
+    auto l_ptr = this->inputNameToLiteral(s);
+    auto l_data_ptr = xla::TransferParameterToServer(*l_ptr);
+    arguments.push_back(l_data_ptr.release());
+  }
+  auto result = xla::ExecuteComputation(computation_, arguments);
 
-  onnxStatus XlaExecutor::sendInputs(const onnxMemoryFence* inputFence)  {
-    auto waitStatus = onnxWaitEvent(*inputFence->event);
-    if (waitStatus != ONNXIFI_STATUS_SUCCESS)  {
-      return waitStatus;
+#define OPERATION(type_to, type_from, vec)                            \
+  type_to* destination = (type_to*)output_buffers_[output_names_[i]]; \
+  for (auto j = 0; j < num_elements; ++j) {                           \
+    destination[j] = (type_to)outputLiterals[i].data<type_from>()[j]; \
+  }                                                                   \
+  break;
+
+  std::vector<Literal> outputLiterals = result->DecomposeTuple();
+  for (auto i = 0; i < outputLiterals.size(); ++i) {
+    int64_t num_elements = 1;
+    for (auto j = 0; j < io_shape_[output_names_[i]].size(); ++j) {
+      num_elements *= io_shape_[output_names_[i]][j].dim;
     }
-    for (const std::string& s : param_input_name_)  {
-      auto l_ptr = this->inputNameToLiteral(s);
-      auto l_data_ptr = xla::TransferParameterToServer(*l_ptr);
-      arguments_.push_back(l_data_ptr.release());
-    }
-    return ONNXIFI_STATUS_SUCCESS;
-  } 
+    SWITCH(io_data_type_[output_names_[i]])
+  }
+  return onnxSignalEvent(*outputFence->event);
+#undef OPERATION
+}
 
-  onnxStatus XlaExecutor::executeComputation(onnxMemoryFence* outputFence) {
-    
-    #define OPERATION(type_to, type_from, vec)                                  \
-      type_to* destination = (type_to*) output_buffers_[output_names_[i]];      \
-      for (auto j = 0; j < num_elements; ++j)  {                                \
-        destination[j] = (type_to) outputLiterals[i].data<type_from>()[j];      \
-      }                                                                         \
-      break; 	 								\
+XlaTransform::XlaTransform(onnxBackend backend,
+                           std::unique_ptr<Graph> ir,
+                           const std::string& build_name,
+                           uint32_t weightsCount,
+                           const onnxTensorDescriptor* weightDescriptors)
+    : weights_count_(weightsCount),
+      weight_descriptors_(weightDescriptors),
+      builder_(build_name),
+      executor_(new XlaExecutor(backend)),
+      global_param_number_(0) {
+  ir_ = std::move(ir);
+}
 
-    auto result = xla::ExecuteComputation(computation_, arguments_);
-    std::vector<Literal> outputLiterals =  result->DecomposeTuple();
-    for (auto i = 0; i < outputLiterals.size(); ++i)  {
-      int64_t num_elements = 1;
-      for (auto j = 0; j < io_shape_[output_names_[i]].size(); ++j)  {
-        num_elements *= io_shape_[output_names_[i]][j].dim;
+XlaTransform::~XlaTransform() {}
+
+inline Shape XlaTransform::shapeOfValue(const Value* v) {
+  std::vector<int64> sizes;
+  for (const Dimension& d : v->sizes()) {
+    ONNX_ASSERT(d.is_int);
+    sizes.push_back(d.dim);
+  }
+  return ShapeUtil::MakeShape(onnxToPrimitive(v->elemType()), sizes);
+}
+
+onnxStatus XlaTransform::handleInputs() {
+  if (ir_->initializers().size() != 0 && weight_descriptors_) {
+    throw std::runtime_error(
+        "Static weights of the graph should be passed through "
+        "ModelProto.graph.initializer,"
+        "or through the weightDescriptors parameters, not both");
+  }
+  if (weights_count_ > 0 && !weight_descriptors_) {
+    return ONNXIFI_STATUS_INVALID_POINTER;
+  }
+  std::unordered_map<std::string, const Value*> inputNameToValue;
+  for (const Value* v : ir_->inputs()) {
+    inputNameToValue[v->uniqueName()] = v;
+  }
+  std::unordered_map<std::string, bool> isInitialized;
+
+  if (weight_descriptors_) {
+    executor_->num_inputs_ =
+        (uint32_t)((int64_t)(ir_->inputs().size()) - (int64_t)(weights_count_));
+    for (auto i = 0; i < weights_count_; ++i) {
+      std::string name(weight_descriptors_[i].name);
+      isInitialized[name] = true;
+      const onnxTensorDescriptor& t = weight_descriptors_[i];
+      const Value* v = inputNameToValue[name];
+      if (t.dataType == v->elemType()) {
+        return ONNXIFI_STATUS_MISMATCHING_DATATYPE;
       }
-      SWITCH(io_data_type_[output_names_[i]])
-    }
-    return onnxSignalEvent(*outputFence->event);
-    #undef OPERATION
-  }
-
-  XlaTransform::XlaTransform(onnxBackend backend, std::unique_ptr<Graph> ir, const std::string& build_name,
-                             uint32_t weightsCount, const onnxTensorDescriptor *weightDescriptors) :
-                             weights_count_(weightsCount), weight_descriptors_(weightDescriptors),
-                             builder_(build_name), executor_(new XlaExecutor(backend)), global_param_number_(0) {
-    ir_ = std::move(ir);
-  }
-
-  XlaTransform::~XlaTransform() {}
-
-  inline Shape XlaTransform::shapeOfValue(const Value* v)  {
-    std::vector<int64> sizes;
-    for (const Dimension& d : v->sizes()) {
-      ONNX_ASSERT(d.is_int);
-      sizes.push_back(d.dim);
-    }
-    return ShapeUtil::MakeShape(onnxToPrimitive(v->elemType()), sizes);
-  }
-
-  onnxStatus XlaTransform::handleInputs()  {
-    if (ir_->initializers().size() != 0 && weight_descriptors_)  {
-      throw std::runtime_error("Static weights of the graph should be passed through ModelProto.graph.initializer,"
-            "or through the weightDescriptors parameters, not both");
-    }
-    if (weights_count_ > 0 && !weight_descriptors_)  {
-      return ONNXIFI_STATUS_INVALID_POINTER;
-    }
-    std::unordered_map<std::string, const Value*> inputNameToValue;
-    for (const Value* v : ir_->inputs()) {
-      inputNameToValue[v->uniqueName()] = v;
-    }
-    std::unordered_map<std::string, bool> isInitialized;
-
-    if (weight_descriptors_)  {
-      executor_->num_inputs_ = (uint32_t) ((int64_t) (ir_->inputs().size()) - (int64_t) (weights_count_));
-      for (auto i = 0; i < weights_count_; ++i)  {
-        std::string name(weight_descriptors_[i].name);
-        isInitialized[name] = true;
-        const onnxTensorDescriptor& t = weight_descriptors_[i];
-        const Value* v = inputNameToValue[name];
-        if (t.dataType == v->elemType()) {
-          return ONNXIFI_STATUS_MISMATCHING_DATATYPE;
-        }
-        if (t.memoryType != ONNXIFI_MEMORY_TYPE_CPU)  {
-          throw std::runtime_error("The weightDescriptors parameters must have"
-                "memoryType ONNXIFI_MEMORY_TYPE_CPU");
-        }
-        if (t.dimensions != v->sizes().size())  {
+      if (t.memoryType != ONNXIFI_MEMORY_TYPE_CPU) {
+        throw std::runtime_error(
+            "The weightDescriptors parameters must have"
+            "memoryType ONNXIFI_MEMORY_TYPE_CPU");
+      }
+      if (t.dimensions != v->sizes().size()) {
+        return ONNXIFI_STATUS_MISMATCHING_SHAPE;
+      }
+      for (auto j = 0; j < t.dimensions; ++j) {
+        if (!v->sizes()[j].is_int || t.shape[j] != v->sizes()[j].dim) {
           return ONNXIFI_STATUS_MISMATCHING_SHAPE;
         }
-        for (auto j = 0; j < t.dimensions; ++j)  {
-          if (!v->sizes()[j].is_int || t.shape[j] != v->sizes()[j].dim)  {
-            return ONNXIFI_STATUS_MISMATCHING_SHAPE;
-          }
-        }   
-        auto l_ptr = executor_->descriptorToLiteral(t);
-        auto constant = builder_.ConstantLiteral(*l_ptr);
-        value_to_op_[v] = constant;
       }
-    } else {
-      executor_->num_inputs_ = (uint32_t) ((int64_t) (ir_->inputs().size()) - (int64_t) (ir_->initializers().size()));
-      for (const Tensor& t : ir_->initializers())  {
-        std::string name(t.name());
-        isInitialized[name] = true;
-        auto l_ptr = executor_->tensorToLiteral(t);
-        auto constant = builder_.ConstantLiteral(*l_ptr);
-        value_to_op_[inputNameToValue[name]] = constant;
-      }
+      auto l_ptr = executor_->descriptorToLiteral(t);
+      auto constant = builder_.ConstantLiteral(*l_ptr);
+      value_to_op_[v] = constant;
     }
-
-    for (const Value* v : ir_->inputs())  {
-      if (isInitialized.find(v->uniqueName()) == isInitialized.end())  {
-        executor_->param_input_name_.push_back(v->uniqueName());
-        auto param = builder_.Parameter(global_param_number_++, shapeOfValue(v),
-                                        v->uniqueName());
-        value_to_op_[v] = param;
-        executor_->io_data_type_[v->uniqueName()] = v->elemType();
-        executor_->io_shape_[v->uniqueName()] = v->sizes();
-      }
+  } else {
+    executor_->num_inputs_ = (uint32_t)((int64_t)(ir_->inputs().size()) -
+                                        (int64_t)(ir_->initializers().size()));
+    for (const Tensor& t : ir_->initializers()) {
+      std::string name(t.name());
+      isInitialized[name] = true;
+      auto l_ptr = executor_->tensorToLiteral(t);
+      auto constant = builder_.ConstantLiteral(*l_ptr);
+      value_to_op_[inputNameToValue[name]] = constant;
     }
-    return ONNXIFI_STATUS_SUCCESS;
   }
-  
-  onnxStatus XlaTransform::handleOutputs()  {
-    executor_->num_outputs_ = (uint32_t) ir_->outputs().size();
-    std::vector<XlaOp> retOps;
-    for(const Value* v : ir_->outputs())  {
+
+  for (const Value* v : ir_->inputs()) {
+    if (isInitialized.find(v->uniqueName()) == isInitialized.end()) {
+      executor_->param_input_name_.push_back(v->uniqueName());
+      auto param = builder_.Parameter(global_param_number_++, shapeOfValue(v),
+                                      v->uniqueName());
+      value_to_op_[v] = param;
       executor_->io_data_type_[v->uniqueName()] = v->elemType();
       executor_->io_shape_[v->uniqueName()] = v->sizes();
-      retOps.push_back(value_to_op_[v]);
-      executor_->output_names_.push_back(v->uniqueName());
     }
-    builder_.Tuple(retOps);
+  }
+  return ONNXIFI_STATUS_SUCCESS;
+}
+
+onnxStatus XlaTransform::handleOutputs() {
+  executor_->num_outputs_ = (uint32_t)ir_->outputs().size();
+  std::vector<XlaOp> retOps;
+  for (const Value* v : ir_->outputs()) {
+    executor_->io_data_type_[v->uniqueName()] = v->elemType();
+    executor_->io_shape_[v->uniqueName()] = v->sizes();
+    retOps.push_back(value_to_op_[v]);
+    executor_->output_names_.push_back(v->uniqueName());
+  }
+  builder_.Tuple(retOps);
+  return ONNXIFI_STATUS_SUCCESS;
+}
+
+onnxStatus XlaTransform::translateGraph() {
+  auto handleInputsStatus = this->handleInputs();
+  if (handleInputsStatus != ONNXIFI_STATUS_SUCCESS) {
+    return handleInputsStatus;
+  }
+  auto& registry = OperatorRegistry::registry();
+  for (auto it = ir_->begin(); it != ir_->end(); ++it) {
+    auto translateStatus = registry.translate(**it, builder_, value_to_op_);
+    if (translateStatus != ONNXIFI_STATUS_SUCCESS) {
+      return translateStatus;
+    }
+  }
+
+  auto handleOutputsStatus = this->handleOutputs();
+  if (handleOutputsStatus != ONNXIFI_STATUS_SUCCESS) {
+    return handleOutputsStatus;
+  }
+  auto computation_status = builder_.Build();
+  if (!computation_status.ok()) {
+    throw std::runtime_error("The graph was not able to be built");
+  }
+  executor_->computation_ = computation_status.ConsumeValueOrDie();
+  return ONNXIFI_STATUS_SUCCESS;
+}
+
+XlaExecutor* XlaTransform::executor() {
+  return executor_.release();
+}
+
+OnnxParser::OnnxParser(const void* serializedModel, size_t serializedModelSize)
+    : serialized_model_(serializedModel),
+      serialized_model_size_(serializedModelSize) {}
+
+onnxStatus OnnxParser::parse(std::unique_ptr<Graph>& ir) {
+  ModelProto deserializedModel;
+  if (!ONNX_NAMESPACE::ParseProtoFromBytes(&deserializedModel,
+                                           (const char*)serialized_model_,
+                                           serialized_model_size_)) {
+    return ONNXIFI_STATUS_INVALID_PROTOBUF;
+  }
+  try {
+    ONNX_NAMESPACE::shape_inference::InferShapes(deserializedModel);
+    ir = ONNX_NAMESPACE::ImportModelProto(deserializedModel);
     return ONNXIFI_STATUS_SUCCESS;
+  } catch (const std::exception& e) {
+    std::cerr << e.what() << std::endl;
+    return ONNXIFI_STATUS_INVALID_MODEL;
+  } catch (...) {
+    return ONNXIFI_STATUS_INVALID_MODEL;
   }
-
-  onnxStatus XlaTransform::translateGraph() {
-    auto handleInputsStatus = this->handleInputs();
-    if (handleInputsStatus != ONNXIFI_STATUS_SUCCESS)  {
-      return handleInputsStatus;
-    }
-    auto& registry = OperatorRegistry::registry();
-    for (auto it = ir_->begin(); it != ir_->end(); ++it) {
-      auto translateStatus = registry.translate(**it, builder_, value_to_op_);
-      if (translateStatus != ONNXIFI_STATUS_SUCCESS)  {
-        return translateStatus;
-      }
-    }
-
-    auto handleOutputsStatus = this->handleOutputs();
-    if (handleOutputsStatus != ONNXIFI_STATUS_SUCCESS)  {
-      return handleOutputsStatus;
-    }
-    auto computation_status = builder_.Build();
-    if (!computation_status.ok())  {
-      throw std::runtime_error("The graph was not able to be built");
-    }
-    executor_->computation_ = computation_status.ConsumeValueOrDie();
-    return ONNXIFI_STATUS_SUCCESS;
-  }
-
-  XlaExecutor* XlaTransform::executor()  {
-    return executor_.release();
-  }
-
-  OnnxParser::OnnxParser(const void* serializedModel, size_t serializedModelSize) :
-                         serialized_model_(serializedModel), 
-                         serialized_model_size_(serializedModelSize) {}
-
-  onnxStatus OnnxParser::parse(std::unique_ptr<Graph>& ir)  {
-    ModelProto deserializedModel;
-    if (!ONNX_NAMESPACE::ParseProtoFromBytes(&deserializedModel,
-                                             (const char*) serialized_model_,
-                                             serialized_model_size_))  {
-      return ONNXIFI_STATUS_INVALID_PROTOBUF;
-    }
-    try {
-      ONNX_NAMESPACE::shape_inference::InferShapes(deserializedModel);
-      ir = ONNX_NAMESPACE::ImportModelProto(deserializedModel);
-      return ONNXIFI_STATUS_SUCCESS;
-    }
-    catch (const std::exception &e) {                          
-      std::cerr << e.what() << std::endl;
-      return ONNXIFI_STATUS_INVALID_MODEL;
-    }            
-    catch (...) {                          
-      return ONNXIFI_STATUS_INVALID_MODEL;
-    }
-  }
-  #undef SWITCH
+}
+#undef SWITCH
 }

--- a/onnx_xla/backend.h
+++ b/onnx_xla/backend.h
@@ -18,154 +18,160 @@
 #include <memory>
 
 namespace onnx_xla {
-  using ::xla::GlobalData;
-  using ::xla::XlaComputation;
-  using ::ONNX_NAMESPACE::ModelProto;
-  using ::ONNX_NAMESPACE::Tensor;
-  using ::ONNX_NAMESPACE::Graph;
+using ::xla::GlobalData;
+using ::xla::XlaComputation;
+using ::ONNX_NAMESPACE::ModelProto;
+using ::ONNX_NAMESPACE::Tensor;
+using ::ONNX_NAMESPACE::Graph;
 
-  class XlaTransform;
-  class XlaExecutor;
-  class OnnxParser;
+class XlaTransform;
+class XlaExecutor;
+class OnnxParser;
 
-  //Engine to execute an XlaComputation constructed by XlaTransform. The computation_
-  //is filled by the XlaTransform object. To run, call initIO to verify IO
-  //metadata and to declare IO locations. Once IO data is present, execute sendInputs
-  //and executeComputation to run. If successful, output tensors will be present at the 
-  //output_buffers_ pointers.
-  class XlaExecutor final  {
-  public:
-    //Constructor initialized with backend handle
-    XlaExecutor(onnxBackend backend);
+// Engine to execute an XlaComputation constructed by XlaTransform. The
+// computation_
+// is filled by the XlaTransform object. To run, call initIO to verify IO
+// metadata and to declare IO locations. Once IO data is present, execute
+// executeComputation
+// to run. If successful, output tensors will be present at the output_buffers_
+// pointers.
+class XlaExecutor final {
+ public:
+  // Constructor initialized with backend handle
+  XlaExecutor(onnxBackend backend);
 
-    //Used to pass IO metadata and locations to the engine
-    onnxStatus initIO(uint32_t inputsCount, const onnxTensorDescriptor* inputDescriptors,
-                uint32_t  outputsCount, const onnxTensorDescriptor* outputDescriptors);
+  // Used to pass IO metadata and locations to the engine
+  onnxStatus initIO(uint32_t inputsCount,
+                    const onnxTensorDescriptor* inputDescriptors,
+                    uint32_t outputsCount,
+                    const onnxTensorDescriptor* outputDescriptors);
 
-    //Sends input tensor values to the server
-    //Input fence (initialized) signals when inputs are ready
-    onnxStatus sendInputs(const onnxMemoryFence* inputFence);
+  // Sends input tensor values to the server
+  // Input fence (initialized) signals when inputs are ready
+  // Runs the computation on the server using passed input
+  // outputFence (initialized) is signalled once outputs are ready
+  onnxStatus executeComputation(const onnxMemoryFence* inputFence,
+                                onnxMemoryFence* outputFence);
 
-    //Runs the computation on the server using passed input 
-    //outputFence (initialized) is signalled once outputs are ready
-    onnxStatus executeComputation(onnxMemoryFence* outputFence);
+  // backend handle
+  const onnxBackend backend_;
 
-    //backend handle
-    const onnxBackend backend_;
-  private:
-    //computation to be run
-    XlaComputation computation_;
+ private:
+  // computation to be run
+  XlaComputation computation_;
 
-    //Input data to be passed to the server
-      //Filled in by sendInputs
-      //Used by executeComputation
-    std::vector<GlobalData*> arguments_;
+  // Store IO metadata to
+  //  Verify IO has correct shape, data type, TODO: memory type
+  //  Get input and output locations
+  uint32_t num_inputs_;
+  uint32_t num_outputs_;
+  std::unordered_map<std::string, ONNX_NAMESPACE::TensorProto_DataType>
+      io_data_type_;
+  std::unordered_map<std::string, std::vector<Dimension>> io_shape_;
+  std::unordered_map<std::string, onnxPointer> input_buffers_;
+  std::unordered_map<std::string, onnxPointer> output_buffers_;
 
-    //Store IO metadata to 
-    //  Verify IO has correct shape, data type, TODO: memory type
-    //  Get input and output locations
-    uint32_t num_inputs_;
-    uint32_t num_outputs_;
-    std::unordered_map<std::string, ONNX_NAMESPACE::TensorProto_DataType> io_data_type_;
-    std::unordered_map<std::string, std::vector<Dimension>> io_shape_;
-    std::unordered_map<std::string, onnxPointer> input_buffers_;
-    std::unordered_map<std::string, onnxPointer> output_buffers_;
+  // Mapping of parameter number to input name; use to fill arguments_ in the
+  // correct order
+  std::vector<std::string> param_input_name_;
 
-    //Mapping of parameter number to input name; use to fill arguments_ in the correct order
-    std::vector<std::string> param_input_name_;
+  // Used to copy output returned from XLA to output buffers
+  std::vector<std::string> output_names_;
 
-    //Used to copy output returned from XLA to output buffers 
-    std::vector<std::string> output_names_;
+  // Helper functions to translate tensors, inputs, and weights to literals
+  std::unique_ptr<Literal> tensorToLiteral(const Tensor& t);
+  std::unique_ptr<Literal> inputNameToLiteral(const std::string& name);
+  std::unique_ptr<Literal> descriptorToLiteral(const onnxTensorDescriptor& t);
 
-    //Helper functions to translate tensors, inputs, and weights to literals
-    std::unique_ptr<Literal> tensorToLiteral(const Tensor& t);
-    std::unique_ptr<Literal> inputNameToLiteral(const std::string& name);
-    std::unique_ptr<Literal> descriptorToLiteral(const onnxTensorDescriptor& t);
-    
-    friend class XlaTransform;
-  };
+  friend class XlaTransform;
+};
 
+// Engine to transform an IR graph to a form that can be executed by the XLA
+// server.
+// When the object is constructed, ownership of the IR graph is passed to it.
+// Then,
+// execute translateGraph to build up the XlaExecutor object (and thus the
+// XlaComputation).
+// To get the handle on the XlaExecutor that is constructed, call executor()
+// (can only be
+// done once).
+class XlaTransform final {
+ public:
+  // Passes IR graph to be transformed, name of builder, and weightDescriptor
+  // info
+  // TODO: Remove build_name? or keep for debugging purposes?
+  XlaTransform(onnxBackend backend,
+               std::unique_ptr<Graph> ir,
+               const std::string& build_name,
+               uint32_t weightsCount,
+               const onnxTensorDescriptor* weightDescriptors);
+  ~XlaTransform();
 
-  //Engine to transform an IR graph to a form that can be executed by the XLA server.
-  //When the object is constructed, ownership of the IR graph is passed to it. Then,
-  //execute translateGraph to build up the XlaExecutor object (and thus the XlaComputation).
-  //To get the handle on the XlaExecutor that is constructed, call executor() (can only be
-  //done once).
-  class XlaTransform final  {
-  public:
-    //Passes IR graph to be transformed, name of builder, and weightDescriptor info
-    //TODO: Remove build_name? or keep for debugging purposes?
-    XlaTransform(onnxBackend backend,
-                 std::unique_ptr<Graph> ir,
-                 const std::string& build_name,
-                 uint32_t weightsCount, 
-                 const onnxTensorDescriptor *weightDescriptors);
-    ~XlaTransform();
+  // Fills up XlaExecutor based on the IR graph. Function accomplishes:
+  //  Initializer/weight values added as constants to the graph
+  //  Fills up executor_'s expected IO metadata, which can be verified in initIO
+  //  Translates IR graph node by node dispatching to operator registry
+  //    TODO: Fix kUndefinded translation, which is present for relu test
+  //  Fills up exector_'s output names
+  //  Returns status
+  onnxStatus translateGraph();
 
-    //Fills up XlaExecutor based on the IR graph. Function accomplishes:
-    //  Initializer/weight values added as constants to the graph 
-    //  Fills up executor_'s expected IO metadata, which can be verified in initIO
-    //  Translates IR graph node by node dispatching to operator registry 
-    //    TODO: Fix kUndefinded translation, which is present for relu test
-    //  Fills up exector_'s output names
-    //  Returns status
-    onnxStatus translateGraph();
+  // Used to get handle to XlaExecutor
+  // NOTE: Can only be called on once as it releases the unique pointer. Freeing
+  // memory must be handled by caller.
+  XlaExecutor* executor();
 
-    //Used to get handle to XlaExecutor
-    //NOTE: Can only be called on once as it releases the unique pointer. Freeing
-    //memory must be handled by caller.
-    XlaExecutor* executor();
+ private:
+  // IR graph to be translated
+  std::unique_ptr<Graph> ir_;
 
-  private:
-    //IR graph to be translated
-    std::unique_ptr<Graph> ir_;
+  // Weight Descriptor information
+  uint32_t weights_count_;
+  const onnxTensorDescriptor* weight_descriptors_;
 
-    //Weight Descriptor information
-    uint32_t weights_count_;
-    const onnxTensorDescriptor* weight_descriptors_;
+  // Builder that builds XlaComputation
+  //  TODO: Remove? Currently only used by one function
+  XlaBuilder builder_;
 
-    //Builder that builds XlaComputation
-    //  TODO: Remove? Currently only used by one function
-    XlaBuilder builder_;
+  // XlaExecutor that is built up to do the computation later
+  std::unique_ptr<XlaExecutor> executor_;
 
-    //XlaExecutor that is built up to do the computation later
-    std::unique_ptr<XlaExecutor> executor_;
+  // Used to keep track of values and XlaOp's
+  // whose output corresponds to them
+  ValueOpMap value_to_op_;
 
-    //Used to keep track of values and XlaOp's
-    //whose output corresponds to them
-    ValueOpMap value_to_op_;
+  // Keeps track of number of parameters in computation
+  //  TODO: Make local? Only used by one function
+  int64 global_param_number_;
 
-    //Keeps track of number of parameters in computation
-    //  TODO: Make local? Only used by one function
-    int64 global_param_number_;
+  // Helper to get shape of associated value
+  static inline Shape shapeOfValue(const Value* v);
 
-    //Helper to get shape of associated value
-    static inline Shape shapeOfValue(const Value* v);
+  // Create ConstantLiteral XlaOps for initializers/weights, verifying weight
+  // descriptors;
+  // Creates params for other runtime inputs
+  // Fill executor_'s input metadata (type, shape) to be verified later
+  onnxStatus handleInputs();
 
+  // Fill output_names_
+  // Create output XlaOp
+  // Fill executor_'s output metadata (type, shape) to be verified later
+  onnxStatus handleOutputs();
+};
 
-    //Create ConstantLiteral XlaOps for initializers/weights, verifying weight descriptors;
-    //Creates params for other runtime inputs
-    //Fill executor_'s input metadata (type, shape) to be verified later
-    onnxStatus handleInputs();
+// Engine to build up an IR graph from proto bytes format. Model validation and
+// shape inference for entire graph is conducted here.
+class OnnxParser {
+ public:
+  // Initializes parser
+  OnnxParser(const void* serializedModel, size_t serializedModelSize);
 
-    //Fill output_names_
-    //Create output XlaOp
-    //Fill executor_'s output metadata (type, shape) to be verified later
-    onnxStatus handleOutputs();
-  };
+  // Deserialize to modelProto, shape inference, and conversion to IR
+  //(model validation) stored in ir
+  onnxStatus parse(std::unique_ptr<Graph>& ir);
 
-  //Engine to build up an IR graph from proto bytes format. Model validation and 
-  //shape inference for entire graph is conducted here.
-  class OnnxParser {
-  public:
-    //Initializes parser
-    OnnxParser(const void* serializedModel, size_t serializedModelSize);
-
-    //Deserialize to modelProto, shape inference, and conversion to IR 
-    //(model validation) stored in ir
-    onnxStatus parse(std::unique_ptr<Graph>& ir);
-  private:
-    const void* serialized_model_;
-    size_t serialized_model_size_;
-  };
+ private:
+  const void* serialized_model_;
+  size_t serialized_model_size_;
+};
 }

--- a/onnx_xla/backend.h
+++ b/onnx_xla/backend.h
@@ -30,8 +30,8 @@ class OnnxParser;
 
 // Engine to execute an XlaComputation constructed by XlaTransform. The
 // computation_ is filled by the XlaTransform object. To run, call initIO
-// to verify IO metadata and to declare IO locations. Once IO data is 
-// present, execute executeComputation to run. If successful, output 
+// to verify IO metadata and to declare IO locations. Once IO data is
+// present, execute executeComputation to run. If successful, output
 // tensors will be present at the output_buffers_ pointers.
 
 class XlaExecutor final {

--- a/onnx_xla/backend_test.cc
+++ b/onnx_xla/backend_test.cc
@@ -149,7 +149,6 @@ void dynamic_relu_test() {
   }
   executor->executeComputation(&inputFence, &outputFence);
 
-
   // Check correctness
   ONNX_ASSERT(outputEvent->signalled_);
   float* output_ptr = (float*)output.buffer;

--- a/onnx_xla/backend_test.cc
+++ b/onnx_xla/backend_test.cc
@@ -3,170 +3,168 @@
 #include <stdlib.h>
 #include <cmath>
 
-namespace onnx_xla  {
+namespace onnx_xla {
 
-  bool almost_equal(float a, float b, float epsilon)  {
-    return std::abs(a - b) < epsilon;
+bool almost_equal(float a, float b, float epsilon) {
+  return std::abs(a - b) < epsilon;
+}
+
+void static_relu_test() {
+  // Set up IR graph
+  std::unique_ptr<Graph> relu_graph(new Graph());
+  relu_graph->setName("relu_graph");
+  Tensor initializer;
+  initializer.elem_type() = ONNX_NAMESPACE::TensorProto_DataType_FLOAT;
+  std::uniform_real_distribution<float> unif(-0.5, 0.5);
+  for (int i = 0; i < 24; ++i) {
+    std::random_device rand_dev;
+    std::mt19937 rand_engine(rand_dev());
+    initializer.floats().push_back(unif(rand_engine));
+  }
+  initializer.sizes().push_back(2);
+  initializer.sizes().push_back(3);
+  initializer.sizes().push_back(4);
+  std::vector<Dimension> sizes;
+  sizes.push_back(2);
+  sizes.push_back(3);
+  sizes.push_back(4);
+  relu_graph->addInitializerAndInput(initializer, "relu_input");
+  auto relu_node = relu_graph->create(Symbol("Relu"), relu_graph->inputs());
+  relu_graph->appendNode(relu_node);
+  auto relu_output = relu_node->output();
+  relu_output->setElemType(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  relu_output->setSizes(sizes);
+  relu_output->setUniqueName("relu_output");
+  relu_graph->return_node()->addInput(relu_output);
+
+  // Set up IO information
+  uint64_t shape[3] = {2, 3, 4};
+  onnxTensorDescriptor output;
+  output.name = "relu_output";
+  output.dataType = ONNXIFI_DATATYPE_FLOAT32;
+  output.memoryType = ONNXIFI_MEMORY_TYPE_CPU;
+  output.dimensions = 3;
+  output.shape = shape;
+  output.buffer = (onnxPointer) new float[24];
+
+  // Setup events
+  // Hacky event usage to make it work (cannot use onnxifi with backend)
+  onnxMemoryFence inputFence;
+  inputFence.type = ONNXIFI_SYNCHRONIZATION_EVENT;
+  auto inputEvent = new EventControl();
+  inputEvent->signalled_ = true;
+  inputFence.event = reinterpret_cast<onnxEvent*>(&inputEvent);
+  onnxMemoryFence outputFence;
+  outputFence.type = ONNXIFI_SYNCHRONIZATION_EVENT;
+  auto outputEvent = new EventControl();
+  outputEvent->signalled_ = false;
+  outputFence.event = reinterpret_cast<onnxEvent*>(&outputEvent);
+
+  // Execute using XLA backend
+  XlaTransform runner(NULL, std::move(relu_graph), "relu", 0, nullptr);
+  runner.translateGraph();
+  auto executor = runner.executor();
+  executor->initIO(0, nullptr, 1, &output);
+  executor->executeComputation(&inputFence, &outputFence);
+
+  // Check correctness
+  ONNX_ASSERT(outputEvent->signalled_);
+  float* output_ptr = (float*)output.buffer;
+  for (int i = 0; i < 24; ++i) {
+    if (initializer.floats()[i] > 0.0f) {
+      ONNX_ASSERT(almost_equal(initializer.floats()[i], output_ptr[i]));
+    } else {
+      ONNX_ASSERT(almost_equal(0.0f, output_ptr[i]));
+    }
   }
 
-  void static_relu_test()  {
-    //Set up IR graph
-    std::unique_ptr<Graph> relu_graph(new Graph());
-    relu_graph->setName("relu_graph");
-    Tensor initializer;
-    initializer.elem_type() = ONNX_NAMESPACE::TensorProto_DataType_FLOAT;
-    std::uniform_real_distribution<float> unif(-0.5, 0.5);
-    for (int i = 0; i < 24; ++i)  {
-      std::random_device rand_dev;
-      std::mt19937 rand_engine(rand_dev());
-      initializer.floats().push_back(unif(rand_engine));
+  // Free memory
+  delete executor;
+  delete[] output_ptr;
+  delete inputEvent;
+  delete outputEvent;
+}
+
+void dynamic_relu_test() {
+  // Set up IR graph
+  std::unique_ptr<Graph> relu_graph(new Graph());
+  relu_graph->setName("relu_graph");
+  Value* relu_input = relu_graph->addInput();
+  std::vector<Dimension> sizes;
+  sizes.push_back(2);
+  sizes.push_back(3);
+  sizes.push_back(4);
+  relu_input->setElemType(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  relu_input->setSizes(sizes);
+  relu_input->setUniqueName("relu_input");
+  auto relu_node = relu_graph->create(Symbol("Relu"), relu_graph->inputs());
+  relu_graph->appendNode(relu_node);
+  auto relu_output = relu_node->output();
+  relu_output->setElemType(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  relu_output->setSizes(sizes);
+  relu_output->setUniqueName("relu_output");
+  relu_graph->return_node()->addInput(relu_output);
+
+  // Set up IO information
+  uint64_t shape[3] = {2, 3, 4};
+  onnxTensorDescriptor output;
+  onnxTensorDescriptor input;
+  output.name = "relu_output";
+  output.dataType = ONNXIFI_DATATYPE_FLOAT32;
+  output.memoryType = ONNXIFI_MEMORY_TYPE_CPU;
+  output.dimensions = 3;
+  output.shape = shape;
+  output.buffer = (onnxPointer) new float[24];
+  input.name = "relu_input";
+  input.dataType = ONNXIFI_DATATYPE_FLOAT32;
+  input.memoryType = ONNXIFI_MEMORY_TYPE_CPU;
+  input.dimensions = 3;
+  input.shape = shape;
+  input.buffer = (onnxPointer) new float[24];
+
+  // Setup events
+  // Hacky event usage to make it work (cannot use onnxifi with backend)
+  onnxMemoryFence inputFence;
+  inputFence.type = ONNXIFI_SYNCHRONIZATION_EVENT;
+  auto inputEvent = new EventControl();
+  inputEvent->signalled_ = true;
+  inputFence.event = reinterpret_cast<onnxEvent*>(&inputEvent);
+  onnxMemoryFence outputFence;
+  outputFence.type = ONNXIFI_SYNCHRONIZATION_EVENT;
+  auto outputEvent = new EventControl();
+  outputEvent->signalled_ = false;
+  outputFence.event = reinterpret_cast<onnxEvent*>(&outputEvent);
+
+  // Execute using XLA backend
+  XlaTransform runner(NULL, std::move(relu_graph), "relu", 0, nullptr);
+  runner.translateGraph();
+  auto executor = runner.executor();
+  executor->initIO(1, &input, 1, &output);
+  float* input_ptr = (float*)input.buffer;
+  std::uniform_real_distribution<float> unif(-0.5, 0.5);
+  for (int i = 0; i < 24; ++i) {
+    std::random_device rand_dev;
+    std::mt19937 rand_engine(rand_dev());
+    input_ptr[i] = unif(rand_engine);
+  }
+  executor->executeComputation(&inputFence, &outputFence);
+
+  // Check correctness
+  ONNX_ASSERT(outputEvent->signalled_);
+  float* output_ptr = (float*)output.buffer;
+  for (int i = 0; i < 24; ++i) {
+    if (input_ptr[i] > 0.0f) {
+      ONNX_ASSERT(almost_equal(input_ptr[i], output_ptr[i]));
+    } else {
+      ONNX_ASSERT(almost_equal(0.0f, output_ptr[i]));
     }
-    initializer.sizes().push_back(2);
-    initializer.sizes().push_back(3);
-    initializer.sizes().push_back(4);
-    std::vector<Dimension> sizes;
-    sizes.push_back(2);
-    sizes.push_back(3);
-    sizes.push_back(4);
-    relu_graph->addInitializerAndInput(initializer, "relu_input");
-    auto relu_node = relu_graph->create(Symbol("Relu"), relu_graph->inputs());
-    relu_graph->appendNode(relu_node);
-    auto relu_output = relu_node->output();
-    relu_output->setElemType(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
-    relu_output->setSizes(sizes);
-    relu_output->setUniqueName("relu_output");
-    relu_graph->return_node()->addInput(relu_output);
-
-    //Set up IO information
-    uint64_t shape[3] = {2, 3, 4};
-    onnxTensorDescriptor output;
-    output.name = "relu_output";
-    output.dataType = ONNXIFI_DATATYPE_FLOAT32;
-    output.memoryType = ONNXIFI_MEMORY_TYPE_CPU;
-    output.dimensions = 3;
-    output.shape = shape;
-    output.buffer = (onnxPointer) new float[24];
-
-    //Setup events
-    //Hacky event usage to make it work (cannot use onnxifi with backend)
-    onnxMemoryFence inputFence;
-    inputFence.type = ONNXIFI_SYNCHRONIZATION_EVENT;
-    auto inputEvent = new EventControl();
-    inputEvent->signalled_ = true;
-    inputFence.event = reinterpret_cast<onnxEvent*>(&inputEvent);
-    onnxMemoryFence outputFence;
-    outputFence.type = ONNXIFI_SYNCHRONIZATION_EVENT;
-    auto outputEvent = new EventControl();
-    outputEvent->signalled_ = false;
-    outputFence.event = reinterpret_cast<onnxEvent*>(&outputEvent);
- 
-    //Execute using XLA backend
-    XlaTransform runner(NULL, std::move(relu_graph), "relu", 0, nullptr);
-    runner.translateGraph();
-    auto executor = runner.executor();
-    executor->initIO(0, nullptr, 1, &output);
-    executor->sendInputs(&inputFence);
-    executor->executeComputation(&outputFence);
-
-    //Check correctness
-    ONNX_ASSERT(outputEvent->signalled_);
-    float* output_ptr = (float*) output.buffer;
-    for (int i = 0; i < 24; ++i)  {
-      if (initializer.floats()[i] > 0.0f)  {
-        ONNX_ASSERT(almost_equal(initializer.floats()[i], output_ptr[i]));
-      } else {
-        ONNX_ASSERT(almost_equal(0.0f, output_ptr[i]));
-      }
-    }
-
-    //Free memory
-    delete executor;
-    delete [] output_ptr;
-    delete inputEvent;
-    delete outputEvent;
   }
 
-  void dynamic_relu_test()  {
-    //Set up IR graph
-    std::unique_ptr<Graph> relu_graph(new Graph());    
-    relu_graph->setName("relu_graph");
-    Value* relu_input = relu_graph->addInput();
-    std::vector<Dimension> sizes;
-    sizes.push_back(2);
-    sizes.push_back(3);
-    sizes.push_back(4);    
-    relu_input->setElemType(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
-    relu_input->setSizes(sizes);
-    relu_input->setUniqueName("relu_input");
-    auto relu_node = relu_graph->create(Symbol("Relu"), relu_graph->inputs());
-    relu_graph->appendNode(relu_node);
-    auto relu_output = relu_node->output();
-    relu_output->setElemType(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
-    relu_output->setSizes(sizes);
-    relu_output->setUniqueName("relu_output");
-    relu_graph->return_node()->addInput(relu_output);
-    
-    //Set up IO information
-    uint64_t shape[3] = {2, 3, 4};
-    onnxTensorDescriptor output;
-    onnxTensorDescriptor input;
-    output.name = "relu_output";
-    output.dataType = ONNXIFI_DATATYPE_FLOAT32;
-    output.memoryType = ONNXIFI_MEMORY_TYPE_CPU;
-    output.dimensions = 3;
-    output.shape = shape;
-    output.buffer = (onnxPointer) new float[24];
-    input.name = "relu_input";
-    input.dataType = ONNXIFI_DATATYPE_FLOAT32;
-    input.memoryType = ONNXIFI_MEMORY_TYPE_CPU;
-    input.dimensions = 3;
-    input.shape = shape;
-    input.buffer = (onnxPointer) new float[24];
-
-    //Setup events
-    //Hacky event usage to make it work (cannot use onnxifi with backend)
-    onnxMemoryFence inputFence;
-    inputFence.type = ONNXIFI_SYNCHRONIZATION_EVENT;
-    auto inputEvent = new EventControl();
-    inputEvent->signalled_ = true;
-    inputFence.event = reinterpret_cast<onnxEvent*>(&inputEvent);
-    onnxMemoryFence outputFence;
-    outputFence.type = ONNXIFI_SYNCHRONIZATION_EVENT;
-    auto outputEvent = new EventControl();
-    outputEvent->signalled_ = false;
-    outputFence.event = reinterpret_cast<onnxEvent*>(&outputEvent);
-
-    //Execute using XLA backend
-    XlaTransform runner(NULL, std::move(relu_graph), "relu", 0, nullptr);
-    runner.translateGraph();
-    auto executor = runner.executor();
-    executor->initIO(1, &input, 1, &output);
-    float* input_ptr = (float*) input.buffer;
-    std::uniform_real_distribution<float> unif(-0.5, 0.5);
-    for (int i = 0; i < 24; ++i)  {
-      std::random_device rand_dev;
-      std::mt19937 rand_engine(rand_dev());
-      input_ptr[i] = unif(rand_engine);
-    }
-    executor->sendInputs(&inputFence);
-    executor->executeComputation(&outputFence);
-
-    //Check correctness
-    ONNX_ASSERT(outputEvent->signalled_);
-    float* output_ptr = (float*) output.buffer;
-    for (int i = 0; i < 24; ++i)  {
-      if (input_ptr[i] > 0.0f)  {
-        ONNX_ASSERT(almost_equal(input_ptr[i], output_ptr[i]));
-      } else {
-        ONNX_ASSERT(almost_equal(0.0f, output_ptr[i]));
-      }
-    }
-
-    //Free memory
-    delete executor;
-    delete [] input_ptr;
-    delete [] output_ptr;
-    delete inputEvent;
-    delete outputEvent;
-  }
+  // Free memory
+  delete executor;
+  delete[] input_ptr;
+  delete[] output_ptr;
+  delete inputEvent;
+  delete outputEvent;
+}
 }

--- a/onnx_xla/onnx_xla_interface.cc
+++ b/onnx_xla/onnx_xla_interface.cc
@@ -5,36 +5,33 @@
 #include <condition_variable>
 #include <functional>
 
-//TODO: Figure out how to determine type of device, what information to store
+// TODO: Figure out how to determine type of device, what information to store
 //      about hardware, and how to modify execution as a result
 
-onnxStatus onnxifiTryCatch(std::function<onnxStatus()> tryBlock)  {
-  try  {                                                   
-    return tryBlock(); 
-  }
-  catch (const std::bad_alloc& e) {                                            
-    std::cerr << "Allocation failed: " << e.what() << std::endl;               
-    return ONNXIFI_STATUS_NO_SYSTEM_MEMORY;                                    
-  }                                                                            
-  catch (const std::exception &e) {                                            
-    std::cerr << "Internal Error: " << e.what() << std::endl;                  
-    return ONNXIFI_STATUS_INTERNAL_ERROR;                                      
-  }                                                                            
-  catch (...) {
-    std::cerr << "Internal Error" << std::endl;                                                                
-    return ONNXIFI_STATUS_INTERNAL_ERROR;                                      
+onnxStatus onnxifiTryCatch(std::function<onnxStatus()> tryBlock) {
+  try {
+    return tryBlock();
+  } catch (const std::bad_alloc& e) {
+    std::cerr << "Allocation failed: " << e.what() << std::endl;
+    return ONNXIFI_STATUS_NO_SYSTEM_MEMORY;
+  } catch (const std::exception& e) {
+    std::cerr << "Internal Error: " << e.what() << std::endl;
+    return ONNXIFI_STATUS_INTERNAL_ERROR;
+  } catch (...) {
+    std::cerr << "Internal Error" << std::endl;
+    return ONNXIFI_STATUS_INTERNAL_ERROR;
   }
 }
 
-//Create 1 backendID
-//TODO: Determining # of CPU, GPU, TPU devices and return
+// Create 1 backendID
+// TODO: Determining # of CPU, GPU, TPU devices and return
 ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI ONNXIFI_SYMBOL_NAME(
-    onnxGetBackendIDs)(onnxBackendID *backendIDs, size_t *numBackends) {
+    onnxGetBackendIDs)(onnxBackendID* backendIDs, size_t* numBackends) {
   return onnxifiTryCatch([&] {
-    if (!numBackends)  {
+    if (!numBackends) {
       return ONNXIFI_STATUS_INVALID_POINTER;
     }
-    if (!backendIDs || *numBackends < 1)  {
+    if (!backendIDs || *numBackends < 1) {
       *numBackends = 1;
       return ONNXIFI_STATUS_FALLBACK;
     }
@@ -44,85 +41,86 @@ ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI ONNXIFI_SYMBOL_NAME(
   });
 }
 
-//Free memory for given backend ID
+// Free memory for given backend ID
 ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI
-ONNXIFI_SYMBOL_NAME(onnxReleaseBackendID)(onnxBackendID backendID) {
+    ONNXIFI_SYMBOL_NAME(onnxReleaseBackendID)(onnxBackendID backendID) {
   return onnxifiTryCatch([&] {
     if (!backendID) {
       return ONNXIFI_STATUS_INVALID_ID;
     }
-    auto *backend_id = reinterpret_cast<OnnxXlaBackendID *>(backendID);
+    auto* backend_id = reinterpret_cast<OnnxXlaBackendID*>(backendID);
     delete backend_id;
     return ONNXIFI_STATUS_SUCCESS;
   });
 }
 
-
-//Returning info for given ID
-//TODO: Make sure this information is correct
-//TODO: Expand for different IDs (TPU/GPU) in the future
-ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI ONNXIFI_SYMBOL_NAME(
-    onnxGetBackendInfo)(onnxBackendID backendID, onnxBackendInfo infoType,
-                        void *infoValue, size_t *infoValueSize) {
+// Returning info for given ID
+// TODO: Make sure this information is correct
+// TODO: Expand for different IDs (TPU/GPU) in the future
+ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI
+    ONNXIFI_SYMBOL_NAME(onnxGetBackendInfo)(onnxBackendID backendID,
+                                            onnxBackendInfo infoType,
+                                            void* infoValue,
+                                            size_t* infoValueSize) {
   return onnxifiTryCatch([&] {
     if (!infoValueSize) {
       return ONNXIFI_STATUS_INVALID_POINTER;
     }
 
-    if (!backendID)  {
+    if (!backendID) {
       return ONNXIFI_STATUS_INVALID_ID;
     }
 
-    auto SET_STRING = [&](const char* str)  {
-                        if (!infoValue || *infoValueSize < strlen(str) + 1)  {
-                          *infoValueSize = strlen(str) + 1;
-                          return ONNXIFI_STATUS_FALLBACK;
-                        }
-                        strncpy((char *)(infoValue), str, *infoValueSize);
-                        *infoValueSize = strlen(str) + 1;
-                        return ONNXIFI_STATUS_SUCCESS;
-                      };
-    auto SET_UINT64 = [&](uint64_t x)  {
-                        if (!infoValue || *infoValueSize < sizeof(uint64_t))  {
-                          *infoValueSize = sizeof(uint64_t);
-                          return ONNXIFI_STATUS_FALLBACK;
-                        }
-                        *(uint64_t *)(infoValue) = x;                                              
-                        *infoValueSize = sizeof(uint64_t);
-                        return ONNXIFI_STATUS_SUCCESS;
-                      };
+    auto SET_STRING = [&](const char* str) {
+      if (!infoValue || *infoValueSize < strlen(str) + 1) {
+        *infoValueSize = strlen(str) + 1;
+        return ONNXIFI_STATUS_FALLBACK;
+      }
+      strncpy((char*)(infoValue), str, *infoValueSize);
+      *infoValueSize = strlen(str) + 1;
+      return ONNXIFI_STATUS_SUCCESS;
+    };
+    auto SET_UINT64 = [&](uint64_t x) {
+      if (!infoValue || *infoValueSize < sizeof(uint64_t)) {
+        *infoValueSize = sizeof(uint64_t);
+        return ONNXIFI_STATUS_FALLBACK;
+      }
+      *(uint64_t*)(infoValue) = x;
+      *infoValueSize = sizeof(uint64_t);
+      return ONNXIFI_STATUS_SUCCESS;
+    };
 
-    switch(infoType)  {
-      case ONNXIFI_BACKEND_NAME:  {
+    switch (infoType) {
+      case ONNXIFI_BACKEND_NAME: {
         return SET_STRING("onnx-xla");
       }
-      case ONNXIFI_BACKEND_VENDOR:  {
+      case ONNXIFI_BACKEND_VENDOR: {
         return SET_STRING("Google");
       }
-      case ONNXIFI_BACKEND_VERSION:  {
+      case ONNXIFI_BACKEND_VERSION: {
         return SET_STRING("1.0.0");
       }
-      case ONNXIFI_BACKEND_EXTENSIONS:  {
+      case ONNXIFI_BACKEND_EXTENSIONS: {
         *infoValueSize = 0;
         return ONNXIFI_STATUS_SUCCESS;
       }
-      case ONNXIFI_BACKEND_DEVICE:  {
+      case ONNXIFI_BACKEND_DEVICE: {
         return SET_STRING("cpu (for now in development)");
       }
-      case ONNXIFI_BACKEND_DEVICE_TYPE:  {
+      case ONNXIFI_BACKEND_DEVICE_TYPE: {
         return SET_UINT64(ONNXIFI_DEVICE_TYPE_CPU);
       }
-      case ONNXIFI_BACKEND_CAPABILITIES:  {
+      case ONNXIFI_BACKEND_CAPABILITIES: {
         return SET_UINT64(0UL);
       }
-      case ONNXIFI_BACKEND_INIT_PROPERTIES:  {
+      case ONNXIFI_BACKEND_INIT_PROPERTIES: {
         return SET_UINT64(0UL);
       }
-      case ONNXIFI_BACKEND_MEMORY_TYPES:  {
+      case ONNXIFI_BACKEND_MEMORY_TYPES: {
         return SET_UINT64(ONNXIFI_MEMORY_TYPE_CPU);
       }
-      case ONNXIFI_BACKEND_MEMORY_SIZE:  {
-        //TODO
+      case ONNXIFI_BACKEND_MEMORY_SIZE: {
+        // TODO
         return ONNXIFI_STATUS_UNSUPPORTED_PARAMETER;
       }
       case ONNXIFI_BACKEND_MAX_GRAPH_SIZE: {
@@ -134,26 +132,25 @@ ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI ONNXIFI_SYMBOL_NAME(
       case ONNXIFI_BACKEND_MACS_FP32: {
         return SET_UINT64(0UL);
       }
-      case ONNXIFI_BACKEND_MACS_FP16:  {
+      case ONNXIFI_BACKEND_MACS_FP16: {
         return SET_UINT64(0UL);
       }
-      case ONNXIFI_BACKEND_MEMORY_BANDWIDTH:  {
+      case ONNXIFI_BACKEND_MEMORY_BANDWIDTH: {
         return SET_UINT64(0UL);
       }
-      case ONNXIFI_BACKEND_CPU_MEMORY_READ_BANDWIDTH:  {
+      case ONNXIFI_BACKEND_CPU_MEMORY_READ_BANDWIDTH: {
         return SET_UINT64(0UL);
       }
-      default:  {
-        return ONNXIFI_STATUS_UNSUPPORTED_PARAMETER;
-      }
+      default: { return ONNXIFI_STATUS_UNSUPPORTED_PARAMETER; }
     }
   });
 }
 
-//TODO: Figure out how to get compatibility e.g. sufficient to run OnnxParser?
-ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI ONNXIFI_SYMBOL_NAME(
-    onnxGetBackendCompatibility)(onnxBackendID backendID, size_t onnxModelSize,
-                                 const void *onnxModel) {
+// TODO: Figure out how to get compatibility e.g. sufficient to run OnnxParser?
+ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI
+    ONNXIFI_SYMBOL_NAME(onnxGetBackendCompatibility)(onnxBackendID backendID,
+                                                     size_t onnxModelSize,
+                                                     const void* onnxModel) {
   return onnxifiTryCatch([&] {
     if (!onnxModel) {
       return ONNXIFI_STATUS_INVALID_POINTER;
@@ -165,40 +162,42 @@ ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI ONNXIFI_SYMBOL_NAME(
   });
 }
 
-//TODO: any arguments to pass?
-//Create and return a BackendControl object
-ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI ONNXIFI_SYMBOL_NAME(
-    onnxInitBackend)(onnxBackendID backendID, const uint64_t *auxPropertiesList,
-                     onnxBackend *backend) {
+// TODO: any arguments to pass?
+// Create and return a BackendControl object
+ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI
+    ONNXIFI_SYMBOL_NAME(onnxInitBackend)(onnxBackendID backendID,
+                                         const uint64_t* auxPropertiesList,
+                                         onnxBackend* backend) {
   return onnxifiTryCatch([&] {
-    auto *backend_id = reinterpret_cast<OnnxXlaBackendID *>(backendID);
+    auto* backend_id = reinterpret_cast<OnnxXlaBackendID*>(backendID);
     *backend = reinterpret_cast<onnxBackend>(new BackendControl(backend_id));
     return ONNXIFI_STATUS_SUCCESS;
   });
 }
 
-//Release BackendControl object
-ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI ONNXIFI_SYMBOL_NAME(
-    onnxReleaseBackend)(onnxBackend backend) {
-  return onnxifiTryCatch([&] {    
+// Release BackendControl object
+ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI
+    ONNXIFI_SYMBOL_NAME(onnxReleaseBackend)(onnxBackend backend) {
+  return onnxifiTryCatch([&] {
     if (!backend) {
       return ONNXIFI_STATUS_INVALID_BACKEND;
     }
-    auto *backendController = reinterpret_cast<BackendControl *>(backend);
+    auto* backendController = reinterpret_cast<BackendControl*>(backend);
     delete backendController;
     return ONNXIFI_STATUS_SUCCESS;
   });
 }
 
-
-//Create and return XlaExecutor object
+// Create and return XlaExecutor object
 // TODO: Ignore the weightDescriptors for now and rely on initialization list
-//TODO: more robust error handling in header file to be included
+// TODO: more robust error handling in header file to be included
 ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI ONNXIFI_SYMBOL_NAME(
-    onnxInitGraph)(onnxBackend backend, size_t onnxModelSize,
-                   const void *onnxModel, uint32_t weightsCount,
-                   const onnxTensorDescriptor *weightDescriptors,
-                   onnxGraph *graph) {
+    onnxInitGraph)(onnxBackend backend,
+                   size_t onnxModelSize,
+                   const void* onnxModel,
+                   uint32_t weightsCount,
+                   const onnxTensorDescriptor* weightDescriptors,
+                   onnxGraph* graph) {
   return onnxifiTryCatch([&] {
     *graph = NULL;
     if (!backend) {
@@ -210,20 +209,21 @@ ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI ONNXIFI_SYMBOL_NAME(
     if (onnxModelSize == 0) {
       return ONNXIFI_STATUS_INVALID_SIZE;
     }
-    auto *backendController = reinterpret_cast<BackendControl *>(backend);
-    return backendController->build(onnxModel, onnxModelSize, weightsCount, 
+    auto* backendController = reinterpret_cast<BackendControl*>(backend);
+    return backendController->build(onnxModel, onnxModelSize, weightsCount,
                                     weightDescriptors, graph);
   });
 }
 
-//Verify IO metadata and use initIO to store location of IO
-//TODO: memoryType field ignored for now
-//TODO: more robust error handling in header file to be included
+// Verify IO metadata and use initIO to store location of IO
+// TODO: memoryType field ignored for now
+// TODO: more robust error handling in header file to be included
 ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI ONNXIFI_SYMBOL_NAME(
-    onnxSetGraphIO)(onnxGraph graph, uint32_t inputsCount,
-                    const onnxTensorDescriptor *inputDescriptors,
+    onnxSetGraphIO)(onnxGraph graph,
+                    uint32_t inputsCount,
+                    const onnxTensorDescriptor* inputDescriptors,
                     uint32_t outputsCount,
-                    const onnxTensorDescriptor *outputDescriptors) {
+                    const onnxTensorDescriptor* outputDescriptors) {
   return onnxifiTryCatch([&] {
     if (!graph) {
       return ONNXIFI_STATUS_INVALID_GRAPH;
@@ -231,74 +231,78 @@ ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI ONNXIFI_SYMBOL_NAME(
     if (!inputDescriptors || !outputDescriptors) {
       return ONNXIFI_STATUS_INVALID_POINTER;
     }
-    auto *executor = reinterpret_cast<onnx_xla::XlaExecutor*>(graph);
-    return executor->initIO(inputsCount, inputDescriptors, outputsCount, outputDescriptors);
+    auto* executor = reinterpret_cast<onnx_xla::XlaExecutor*>(graph);
+    return executor->initIO(inputsCount, inputDescriptors, outputsCount,
+                            outputDescriptors);
   });
 }
 
-//Runs the XlaExecutor by sending literals to server and executing computation 
-//TODO: support for synchronization primitives; For now assume, they are always set
-//TODO: more robust error handling in header file to be included
-ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI ONNXIFI_SYMBOL_NAME(
-    onnxRunGraph)(onnxGraph graph, const onnxMemoryFence *inputFence,
-                  onnxMemoryFence *outputFence) {
- return onnxifiTryCatch([&] {
-    if (!graph) {
-      return ONNXIFI_STATUS_INVALID_GRAPH;
-    }
-    //TODO: Status code specific to events
-    //TODO: Inform user that only ONNXIFI_SYNCHRONIZATION_EVENT is the only acceptable type
-    if (!inputFence)  {
-      throw std::runtime_error("Invalid input memory fence");
-    }
-    if (inputFence->type != ONNXIFI_SYNCHRONIZATION_EVENT)  {
-      throw std::runtime_error("The input memory fence must have type ONNXIFI_SYNCHRONIZATION_EVENT. "
-            "The event must be initialized.");
-    }
-    if (!outputFence)  {
-      throw std::runtime_error("Invalid output memory fence");
-    }
-    if (outputFence->type != ONNXIFI_SYNCHRONIZATION_EVENT)  {
-      throw std::runtime_error("The output memory fence must have type ONNXIFI_SYNCHRONIZATION_EVENT. "
-            "The event cannot be initialized.");
-    }
-   
-    auto *executor = reinterpret_cast<onnx_xla::XlaExecutor *>(graph);
-    auto initStatus = onnxInitEvent(executor->backend_, outputFence->event);
-    if (initStatus != ONNXIFI_STATUS_SUCCESS)  {
-      return initStatus;
-    }
-    auto sendInputsStatus = executor->sendInputs(inputFence);
-    if (sendInputsStatus != ONNXIFI_STATUS_SUCCESS)  {
-      return sendInputsStatus;
-    }
-    return executor->executeComputation(outputFence);
-  });
-}
-
-//Frees executor memory
-ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI ONNXIFI_SYMBOL_NAME(
-    onnxReleaseGraph)(onnxGraph graph) {
+// Runs the XlaExecutor by sending literals to server and executing computation
+// TODO: support for synchronization primitives; For now assume, they are always
+// set
+// TODO: more robust error handling in header file to be included
+ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI
+    ONNXIFI_SYMBOL_NAME(onnxRunGraph)(onnxGraph graph,
+                                      const onnxMemoryFence* inputFence,
+                                      onnxMemoryFence* outputFence) {
   return onnxifiTryCatch([&] {
     if (!graph) {
       return ONNXIFI_STATUS_INVALID_GRAPH;
     }
-    auto *executor = reinterpret_cast<onnx_xla::XlaExecutor *>(graph);
+    // TODO: Status code specific to events
+    // TODO: Inform user that only ONNXIFI_SYNCHRONIZATION_EVENT is the only
+    // acceptable type
+    if (!inputFence) {
+      throw std::runtime_error("Invalid input memory fence");
+    }
+    if (inputFence->type != ONNXIFI_SYNCHRONIZATION_EVENT) {
+      throw std::runtime_error(
+          "The input memory fence must have type "
+          "ONNXIFI_SYNCHRONIZATION_EVENT. "
+          "The event must be initialized.");
+    }
+    if (!outputFence) {
+      throw std::runtime_error("Invalid output memory fence");
+    }
+    if (outputFence->type != ONNXIFI_SYNCHRONIZATION_EVENT) {
+      throw std::runtime_error(
+          "The output memory fence must have type "
+          "ONNXIFI_SYNCHRONIZATION_EVENT. "
+          "The event cannot be initialized.");
+    }
+
+    auto* executor = reinterpret_cast<onnx_xla::XlaExecutor*>(graph);
+    auto initStatus = onnxInitEvent(executor->backend_, outputFence->event);
+    if (initStatus != ONNXIFI_STATUS_SUCCESS) {
+      return initStatus;
+    }
+    return executor->executeComputation(inputFence, outputFence);
+  });
+}
+
+// Frees executor memory
+ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI
+    ONNXIFI_SYMBOL_NAME(onnxReleaseGraph)(onnxGraph graph) {
+  return onnxifiTryCatch([&] {
+    if (!graph) {
+      return ONNXIFI_STATUS_INVALID_GRAPH;
+    }
+    auto* executor = reinterpret_cast<onnx_xla::XlaExecutor*>(graph);
     delete executor;
     return ONNXIFI_STATUS_SUCCESS;
   });
 }
 
-//Initialize event by creating EventControl object on the heap
-ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI ONNXIFI_SYMBOL_NAME(
-    onnxInitEvent)(onnxBackend backend, onnxEvent* event) {
+// Initialize event by creating EventControl object on the heap
+ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI
+    ONNXIFI_SYMBOL_NAME(onnxInitEvent)(onnxBackend backend, onnxEvent* event) {
   return onnxifiTryCatch([&] {
-    if (!event)  {
+    if (!event) {
       return ONNXIFI_STATUS_INVALID_POINTER;
     }
     *event = NULL;
 
-    if (!backend)  {
+    if (!backend) {
       return ONNXIFI_STATUS_INVALID_BACKEND;
     }
 
@@ -307,51 +311,51 @@ ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI ONNXIFI_SYMBOL_NAME(
   });
 }
 
-//Signal Event by changing the signalled boolean under mutex hold
-ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI ONNXIFI_SYMBOL_NAME(
-    onnxSignalEvent)(onnxEvent event)  {
-  return onnxifiTryCatch([&] {    
-    if (!event)  {
+// Signal Event by changing the signalled boolean under mutex hold
+ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI
+    ONNXIFI_SYMBOL_NAME(onnxSignalEvent)(onnxEvent event) {
+  return onnxifiTryCatch([&] {
+    if (!event) {
       return ONNXIFI_STATUS_INVALID_EVENT;
     }
-    auto *eventController = reinterpret_cast<EventControl *>(event);
+    auto* eventController = reinterpret_cast<EventControl*>(event);
     {
-       std::lock_guard<std::mutex> lk(eventController->mutex_);
-       if (eventController->signalled_)  {
-         return ONNXIFI_STATUS_INVALID_STATE;
-       }
-       eventController->signalled_ = true;
+      std::lock_guard<std::mutex> lk(eventController->mutex_);
+      if (eventController->signalled_) {
+        return ONNXIFI_STATUS_INVALID_STATE;
+      }
+      eventController->signalled_ = true;
     }
     eventController->condvar_.notify_all();
     return ONNXIFI_STATUS_SUCCESS;
   });
 }
 
-//Wait for signalled to be turned true using conditional variable to coordinate
-ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI ONNXIFI_SYMBOL_NAME(
-    onnxWaitEvent)(onnxEvent event)  {
+// Wait for signalled to be turned true using conditional variable to coordinate
+ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI
+    ONNXIFI_SYMBOL_NAME(onnxWaitEvent)(onnxEvent event) {
   return onnxifiTryCatch([&] {
-    if (!event)  {
+    if (!event) {
       return ONNXIFI_STATUS_INVALID_EVENT;
     }
-    
-    auto *eventController = reinterpret_cast<EventControl *>(event);  
+
+    auto* eventController = reinterpret_cast<EventControl*>(event);
     std::unique_lock<std::mutex> lk(eventController->mutex_);
-    eventController->condvar_.wait(lk, [&eventController]
-                                       {return eventController->signalled_;});
-        
+    eventController->condvar_.wait(
+        lk, [&eventController] { return eventController->signalled_; });
+
     return ONNXIFI_STATUS_SUCCESS;
   });
 }
 
-//Free memory that was allocated for the EventControl object
-ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI ONNXIFI_SYMBOL_NAME(
-    onnxReleaseEvent)(onnxEvent event)  {
+// Free memory that was allocated for the EventControl object
+ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI
+    ONNXIFI_SYMBOL_NAME(onnxReleaseEvent)(onnxEvent event) {
   return onnxifiTryCatch([&] {
-    if (!event)  {
+    if (!event) {
       return ONNXIFI_STATUS_INVALID_EVENT;
     }
-    auto *eventController = reinterpret_cast<EventControl *>(event);
+    auto* eventController = reinterpret_cast<EventControl*>(event);
     delete eventController;
     return ONNXIFI_STATUS_SUCCESS;
   });

--- a/test.py
+++ b/test.py
@@ -44,3 +44,16 @@ print("Input")
 print(x)
 np.testing.assert_equal(expected_outputs, outputs)
 
+#Running graph again
+x = np.random.randn(1, 2).astype(np.float32)
+y = np.maximum(x, 0)
+
+outputs = backendrep.run([x])
+expected_outputs = [y]
+
+print("Output")
+print(expected_outputs[0])
+print("Input")
+print(x)
+np.testing.assert_equal(expected_outputs, outputs)
+


### PR DESCRIPTION
Fusing together function to sendInputs and executeComputation and making arguments local.
1) Solves bug that wasn't allowing graph to be run more than once (as arguments was not being reset)
2) Fixes memory leak issue (XLA's executeComputation expects arguments to be a vector of pointers, which it then deletes).

I will change the macro structure of the file in a separate PR. Also, my clang-format PR has not gone through, so just pay attention to the executeComputation function in backend.cc.
@bddppq @yinghai @Maratyszcza